### PR TITLE
Version 1.13

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-# ReformCloud 1.12
+# ReformCloud 1.12.1
 
 Official Cloud System
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-# ReformCloud 1.12.1
+# ReformCloud 1.13
 
 Official Cloud System
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 
-        <api.default.version>112PRESTABLE07062349</api.default.version>
+        <api.default.version>1121PRESTABLE02071945</api.default.version>
         <service.type>PRE-STABLE</service.type>
 
-        <service.version>1.12</service.version>
+        <service.version>1.12.1</service.version>
 
         <plugin.shade.version>3.2.1</plugin.shade.version>
         <plugin.compiler.version>3.8.1</plugin.compiler.version>
@@ -64,7 +64,7 @@
         </developer>
     </developers>
 
-    <version>1.12</version>
+    <version>1.12.1</version>
 
     <build>
         <defaultGoal>clean install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 
-        <api.default.version>1121PRESTABLE02071945</api.default.version>
+        <api.default.version>113PRESTABLE290719953</api.default.version>
         <service.type>PRE-STABLE</service.type>
 
-        <service.version>1.12.1</service.version>
+        <service.version>1.13</service.version>
 
         <plugin.shade.version>3.2.1</plugin.shade.version>
         <plugin.compiler.version>3.8.1</plugin.compiler.version>
@@ -64,7 +64,7 @@
         </developer>
     </developers>
 
-    <version>1.12.1</version>
+    <version>1.13</version>
 
     <build>
         <defaultGoal>clean package</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency.jline.version>2.14.6</dependency.jline.version>
         <dependency.bungeecord.version>1.8-1.12</dependency.bungeecord.version>
         <dependency.gson.version>2.8.5</dependency.gson.version>
-        <dependency.netty.version>4.1.37.Final</dependency.netty.version>
+        <dependency.netty.version>4.1.38.Final</dependency.netty.version>
         <dependency.spigot.version>1.13</dependency.spigot.version>
         <dependency.snakeyaml.version>1.24</dependency.snakeyaml.version>
         <dependency.commons-io.version>2.6</dependency.commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <version>1.12.1</version>
 
     <build>
-        <defaultGoal>clean install</defaultGoal>
+        <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/reformcloud-addons/pom.xml
+++ b/reformcloud-addons/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-controller</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -35,6 +35,6 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 </project>

--- a/reformcloud-addons/pom.xml
+++ b/reformcloud-addons/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-controller</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -35,6 +35,6 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 </project>

--- a/reformcloud-addons/reformcloud-addons-autoicon/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-autoicon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-autoicon/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-autoicon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-backup/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-backup/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-backup/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-backup/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-cloudflare/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-cloudflare/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-cloudflare/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-cloudflare/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-cloudflare/src/main/java/systems/reformcloud/CloudFlareAddon.java
+++ b/reformcloud-addons/reformcloud-addons-cloudflare/src/main/java/systems/reformcloud/CloudFlareAddon.java
@@ -4,7 +4,6 @@
 
 package systems.reformcloud;
 
-import java.io.Serializable;
 import systems.reformcloud.event.utility.Listener;
 import systems.reformcloud.listeners.client.ClientCreatedListener;
 import systems.reformcloud.listeners.client.ClientDeletedListener;
@@ -12,17 +11,21 @@ import systems.reformcloud.listeners.proxy.ProxyStartedListener;
 import systems.reformcloud.listeners.proxy.ProxyStoppedListener;
 import systems.reformcloud.utility.ControllerAddonImpl;
 
+import java.io.Serializable;
+
 /**
  * @author _Klaro | Pasqual K. / created on 09.05.2019
  */
 
 public final class CloudFlareAddon extends ControllerAddonImpl implements Serializable {
 
-    private Listener
-        proxyStartedListener = new ProxyStartedListener(),
-        proxyStoppedListener = new ProxyStoppedListener(),
-        clientCreatedListener = new ClientCreatedListener(),
-        clientDeletedListener = new ClientDeletedListener();
+    private Listener proxyStartedListener = new ProxyStartedListener();
+
+    private Listener proxyStoppedListener = new ProxyStoppedListener();
+
+    private Listener clientCreatedListener = new ClientCreatedListener();
+
+    private Listener clientDeletedListener = new ClientDeletedListener();
 
     @Override
     public void onAddonLoading() {

--- a/reformcloud-addons/reformcloud-addons-cloudflare/src/main/java/systems/reformcloud/config/config/CloudFlareConfig.java
+++ b/reformcloud-addons/reformcloud-addons-cloudflare/src/main/java/systems/reformcloud/config/config/CloudFlareConfig.java
@@ -76,7 +76,9 @@ public final class CloudFlareConfig implements Serializable {
 
     public static class CloudFlareGroup implements Serializable {
 
-        private String targetProxyGroup, subDomain;
+        private String targetProxyGroup;
+
+        private String subDomain;
 
         @ConstructorProperties({"targetProxyGroup", "subDomain"})
         public CloudFlareGroup(String targetProxyGroup, String subDomain) {

--- a/reformcloud-addons/reformcloud-addons-cloudflare/src/main/java/systems/reformcloud/util/RequestMethod.java
+++ b/reformcloud-addons/reformcloud-addons-cloudflare/src/main/java/systems/reformcloud/util/RequestMethod.java
@@ -11,8 +11,11 @@ import java.io.Serializable;
  */
 
 public enum RequestMethod implements Serializable {
+
     POST("POST"),
+
     DELETE("DELETE"),
+
     GET("GET");
 
     private String stringValue;

--- a/reformcloud-addons/reformcloud-addons-discordbot/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-discordbot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-discordbot/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-discordbot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-mobs/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-mobs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-mobs/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-mobs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-mobs/src/main/java/systems/reformcloud/selector/MobSelector.java
+++ b/reformcloud-addons/reformcloud-addons-mobs/src/main/java/systems/reformcloud/selector/MobSelector.java
@@ -5,14 +5,6 @@
 package systems.reformcloud.selector;
 
 import com.google.gson.reflect.TypeToken;
-import java.io.Serializable;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.ReformCloudLibraryService;
 import systems.reformcloud.configurations.Configuration;
@@ -25,13 +17,14 @@ import systems.reformcloud.mobs.inventory.item.SelectorsMobServerItem;
 import systems.reformcloud.packets.in.PacketInCreateMob;
 import systems.reformcloud.packets.in.PacketInDeleteMob;
 import systems.reformcloud.packets.in.PacketInQueryGetAll;
-import systems.reformcloud.packets.out.PacketOutCreateMob;
-import systems.reformcloud.packets.out.PacketOutDeleteMob;
-import systems.reformcloud.packets.out.PacketOutDisableMobs;
-import systems.reformcloud.packets.out.PacketOutEnableMobs;
-import systems.reformcloud.packets.out.PacketOutUpdateMobs;
+import systems.reformcloud.packets.out.*;
 import systems.reformcloud.utility.Require;
 import systems.reformcloud.utility.files.FileUtils;
+
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
 
 /**
  * @author _Klaro | Pasqual K. / created on 21.04.2019
@@ -41,8 +34,9 @@ public final class MobSelector implements Serializable {
 
     private static MobSelector instance;
 
-    private final String directory = "reformcloud/addons/mobs",
-        databaseDir = "reformcloud/database/mobs";
+    private final String directory = "reformcloud/addons/mobs";
+
+    private final String databaseDir = "reformcloud/database/mobs";
 
     private Map<UUID, SelectorMob> mobs = new HashMap<>();
 

--- a/reformcloud-addons/reformcloud-addons-parameters/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-parameters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-parameters/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-parameters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-permissions/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-permissions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-permissions/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-permissions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-permissions/src/main/java/systems/reformcloud/commands/CommandPermissions.java
+++ b/reformcloud-addons/reformcloud-addons-permissions/src/main/java/systems/reformcloud/commands/CommandPermissions.java
@@ -34,9 +34,6 @@ public final class CommandPermissions extends Command implements Serializable {
             List<PermissionGroup> registered = PermissionsAddon.getInstance()
                 .getPermissionDatabase()
                 .getAllGroups();
-            registered.add(
-                PermissionsAddon.getInstance().getPermissionDatabase().getPermissionCache()
-                    .getDefaultGroup());
             registered.sort((os, as) -> {
                 int id1 = os.getGroupID();
                 int id2 = as.getGroupID();

--- a/reformcloud-addons/reformcloud-addons-properties/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-properties/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-properties/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-properties/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-proxy/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-proxy/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-signs/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-signs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-addons/reformcloud-addons-signs/pom.xml
+++ b/reformcloud-addons/reformcloud-addons-signs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-addons</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-common/pom.xml
+++ b/reformcloud-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-common/pom.xml
+++ b/reformcloud-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-common/reformcloud-yaml/pom.xml
+++ b/reformcloud-common/reformcloud-yaml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-common</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-common/reformcloud-yaml/pom.xml
+++ b/reformcloud-common/reformcloud-yaml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-common</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/pom.xml
+++ b/reformcloud-global/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-library</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -24,6 +24,6 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 </project>

--- a/reformcloud-global/pom.xml
+++ b/reformcloud-global/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-library</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -24,6 +24,6 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 </project>

--- a/reformcloud-global/reformcloud-api/pom.xml
+++ b/reformcloud-global/reformcloud-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-global</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/reformcloud-api/pom.xml
+++ b/reformcloud-global/reformcloud-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-global</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/pom.xml
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-api</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/pom.xml
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-api</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/ReformCloudAPIBungee.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/ReformCloudAPIBungee.java
@@ -335,7 +335,8 @@ public final class ReformCloudAPIBungee implements APIService, Serializable {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -375,7 +376,8 @@ public final class ReformCloudAPIBungee implements APIService, Serializable {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            SpigotVersions.SPIGOT_1_8_8
+            SpigotVersions.SPIGOT_1_8_8,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -399,7 +401,8 @@ public final class ReformCloudAPIBungee implements APIService, Serializable {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/ReformCloudAPIBungee.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/ReformCloudAPIBungee.java
@@ -100,6 +100,7 @@ import systems.reformcloud.network.packets.PacketOutUpdateProxyGroup;
 import systems.reformcloud.network.packets.PacketOutUpdateProxyInfo;
 import systems.reformcloud.network.packets.PacketOutUpdateServerGroup;
 import systems.reformcloud.network.packets.PacketOutUpdateServerInfo;
+import systems.reformcloud.network.query.in.PacketInQueryGetOnlinePlayers;
 import systems.reformcloud.network.query.in.PacketInQueryGetRuntimeInformation;
 import systems.reformcloud.network.query.out.PacketOutQueryGetOnlinePlayer;
 import systems.reformcloud.network.query.out.PacketOutQueryGetPlayer;
@@ -202,6 +203,7 @@ public final class ReformCloudAPIBungee implements APIService, Serializable {
             .registerHandler("UpdatePermissionGroup", new PacketInUpdatePermissionGroup())
             .registerHandler("UpdatePermissionHolder", new PacketInUpdatePermissionHolder())
             .registerQueryHandler("GetRuntimeInformation", new PacketInQueryGetRuntimeInformation())
+            .registerQueryHandler("GetOnlinePlayers", new PacketInQueryGetOnlinePlayers())
             .registerHandler("ServerInfoUpdate", new PacketInServerInfoUpdate());
 
         this.nettySocketClient = new NettySocketClient();

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/ReformCloudAPIBungee.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/ReformCloudAPIBungee.java
@@ -6,28 +6,10 @@ package systems.reformcloud;
 
 import com.google.common.base.Enums;
 import com.google.gson.reflect.TypeToken;
-import java.io.Serializable;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import systems.reformcloud.api.APIService;
-import systems.reformcloud.api.DefaultPermissionHelper;
-import systems.reformcloud.api.DefaultPlayerProvider;
-import systems.reformcloud.api.EventHandler;
-import systems.reformcloud.api.SaveAPIImpl;
+import systems.reformcloud.api.*;
 import systems.reformcloud.api.permissions.PermissionHelper;
 import systems.reformcloud.api.save.SaveAPIService;
 import systems.reformcloud.commands.ingame.command.IngameCommand;
@@ -63,43 +45,11 @@ import systems.reformcloud.network.NettySocketClient;
 import systems.reformcloud.network.abstracts.AbstractChannelHandler;
 import systems.reformcloud.network.api.event.NetworkEventAdapter;
 import systems.reformcloud.network.channel.ChannelHandler;
-import systems.reformcloud.network.in.PacketInConnectPlayer;
-import systems.reformcloud.network.in.PacketInDisableIcons;
-import systems.reformcloud.network.in.PacketInEnableDebug;
-import systems.reformcloud.network.in.PacketInEnableIcons;
-import systems.reformcloud.network.in.PacketInInitializeInternal;
-import systems.reformcloud.network.in.PacketInKickPlayer;
-import systems.reformcloud.network.in.PacketInProcessAdd;
-import systems.reformcloud.network.in.PacketInProcessRemove;
-import systems.reformcloud.network.in.PacketInProxyInfoUpdate;
-import systems.reformcloud.network.in.PacketInSendPlayerMessage;
-import systems.reformcloud.network.in.PacketInServerInfoUpdate;
-import systems.reformcloud.network.in.PacketInSyncControllerTime;
-import systems.reformcloud.network.in.PacketInUpdateAll;
-import systems.reformcloud.network.in.PacketInUpdateIngameCommands;
-import systems.reformcloud.network.in.PacketInUpdatePermissionCache;
-import systems.reformcloud.network.in.PacketInUpdatePermissionGroup;
-import systems.reformcloud.network.in.PacketInUpdatePermissionHolder;
-import systems.reformcloud.network.in.PacketInUpdateProxySettings;
+import systems.reformcloud.network.in.*;
 import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packet.PacketFuture;
-import systems.reformcloud.network.packets.PacketOutCreateClient;
-import systems.reformcloud.network.packets.PacketOutCreateProxyGroup;
-import systems.reformcloud.network.packets.PacketOutCreateServerGroup;
-import systems.reformcloud.network.packets.PacketOutCreateWebUser;
-import systems.reformcloud.network.packets.PacketOutDispatchConsoleCommand;
-import systems.reformcloud.network.packets.PacketOutExecuteCommand;
-import systems.reformcloud.network.packets.PacketOutExecuteCommandSilent;
-import systems.reformcloud.network.packets.PacketOutStartGameServer;
-import systems.reformcloud.network.packets.PacketOutStartProxy;
-import systems.reformcloud.network.packets.PacketOutStopProcess;
-import systems.reformcloud.network.packets.PacketOutUpdateOfflinePlayer;
-import systems.reformcloud.network.packets.PacketOutUpdateOnlinePlayer;
-import systems.reformcloud.network.packets.PacketOutUpdateProxyGroup;
-import systems.reformcloud.network.packets.PacketOutUpdateProxyInfo;
-import systems.reformcloud.network.packets.PacketOutUpdateServerGroup;
-import systems.reformcloud.network.packets.PacketOutUpdateServerInfo;
+import systems.reformcloud.network.packets.*;
 import systems.reformcloud.network.query.in.PacketInQueryGetOnlinePlayers;
 import systems.reformcloud.network.query.in.PacketInQueryGetRuntimeInformation;
 import systems.reformcloud.network.query.out.PacketOutQueryGetOnlinePlayer;
@@ -117,6 +67,13 @@ import systems.reformcloud.utility.TypeTokenAdaptor;
 import systems.reformcloud.utility.cloudsystem.EthernetAddress;
 import systems.reformcloud.utility.cloudsystem.InternalCloudNetwork;
 import systems.reformcloud.utility.defaults.DefaultCloudService;
+
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * @author _Klaro | Pasqual K. / created on 01.11.2018
@@ -562,6 +519,36 @@ public final class ReformCloudAPIBungee implements APIService, Serializable {
     public void updateServerGroup(ServerGroup serverGroup) {
         channelHandler.sendPacketSynchronized("ReformCloudController",
             new PacketOutUpdateServerGroup(serverGroup));
+    }
+
+    @Override
+    public void updateServerName(ServerInfo serverInfo, String newName) {
+        if (serverInfo == null || newName == null) {
+            return;
+        }
+
+        serverInfo.getCloudProcess().setName(newName);
+        this.updateServerInfo(serverInfo);
+    }
+
+    @Override
+    public void updateServerName(String serverName, String newName) {
+        this.updateServerName(this.getServerInfo(serverName), newName);
+    }
+
+    @Override
+    public void updateProxyName(ProxyInfo proxyInfo, String newName) {
+        if (proxyInfo == null || newName == null) {
+            return;
+        }
+
+        proxyInfo.getCloudProcess().setName(newName);
+        this.updateProxyInfo(proxyInfo);
+    }
+
+    @Override
+    public void updateProxyName(String proxyName, String newName) {
+        this.updateProxyName(this.getProxyInfo(proxyName), newName);
     }
 
     @Override

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -253,7 +253,7 @@ public final class CommandReformCloud extends Command implements Serializable, T
                                 .getServerProcessManager().getAllRegisteredProxyProcesses().stream()
                                 .filter(proxyInfo -> proxyInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSender.sendMessage(TextComponent.fromLegacyText(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getProxyGroup().isMaintenance() + "§7 | Player: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Player: §e" + info
                                     .getOnline() + "§7/§e" + info.getProxyGroup().getMaxPlayers())));
                             commandSender.sendMessage(TextComponent.fromLegacyText(""));
                         } else {
@@ -271,7 +271,7 @@ public final class CommandReformCloud extends Command implements Serializable, T
                                 .getServerProcessManager().getAllRegisteredServerProcesses().stream()
                                 .filter(serverInfo -> serverInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSender.sendMessage(TextComponent.fromLegacyText(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getServerGroup().isMaintenance() + "§r | State: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | State: §e" + info
                                     .getServerState() + "§7 | Player: §e" + info.getOnline() + "§7/§e" + info
                                     .getServerGroup().getMaxPlayers())));
                             commandSender.sendMessage(TextComponent.fromLegacyText(""));

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -23,6 +23,7 @@ import systems.reformcloud.meta.info.ClientInfo;
 import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.meta.proxy.ProxyGroup;
+import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.network.packets.PacketOutDispatchConsoleCommand;
 import systems.reformcloud.utility.StringUtil;
 
@@ -81,17 +82,35 @@ public final class CommandReformCloud extends Command implements Serializable, T
         }
 
         if (strings[0].equalsIgnoreCase("maintenance")) {
-            ProxyGroup proxyGroup =
-                ReformCloudAPIBungee.getInstance().getProxyInfo().getProxyGroup();
-            ReformCloudAPIBungee.getInstance().dispatchConsoleCommand(
-                "asg proxygroup " + proxyGroup.getName() +
-                    " maintenance " + (proxyGroup.isMaintenance() ? "false --update" :
-                    "true --update")
-            );
-            commandSender.sendMessage(TextComponent.fromLegacyText(
-                ReformCloudAPIBungee.getInstance().getInternalCloudNetwork()
-                    .getMessage("internal-api-bungee-command-send-controller")
-            ));
+            if (strings.length != 2) {
+                ProxyGroup proxyGroup =
+                    ReformCloudAPIBungee.getInstance().getProxyInfo().getProxyGroup();
+                ReformCloudAPIBungee.getInstance().dispatchConsoleCommand(
+                    "asg proxygroup " + proxyGroup.getName() +
+                        " maintenance " + (proxyGroup.isMaintenance() ? "false --update" :
+                        "true --update")
+                );
+                commandSender.sendMessage(TextComponent.fromLegacyText(
+                    ReformCloudAPIBungee.getInstance().getInternalCloudNetwork()
+                        .getMessage("internal-api-bungee-command-send-controller")
+                ));
+                return;
+            }
+            ServerGroup serverGroup =
+                ReformCloudAPIBungee.getInstance().getServerGroup(strings[1]);
+            if (serverGroup != null) {
+                ReformCloudAPIBungee.getInstance().dispatchConsoleCommand(
+                    "asg servergroup " + serverGroup.getName() +
+                        " maintenance " + (serverGroup.isMaintenance() ? "false" : "true") +
+                        " --update"
+                );
+                commandSender.sendMessage(TextComponent.fromLegacyText(
+                    ReformCloudAPIBungee.getInstance().getInternalCloudNetwork()
+                        .getMessage("internal-api-bungee-command-send-controller")
+                ));
+                return;
+            }
+            commandSender.sendMessage(TextComponent.fromLegacyText(prefix + "§cThe servergroup doesn't exists"));
             return;
         }
 
@@ -337,6 +356,10 @@ public final class CommandReformCloud extends Command implements Serializable, T
             return new LinkedList<>();
         }
 
+        if (strings.length == 2 && strings[0].equalsIgnoreCase("maintenance")) {
+            return registeredServerGroups();
+        }
+
         if (strings.length == 2 && strings[0].equalsIgnoreCase("copy")) {
             return registered();
         }
@@ -457,7 +480,7 @@ public final class CommandReformCloud extends Command implements Serializable, T
             new TextComponent(TextComponent.fromLegacyText(
                 prefix + "§7/reformcloud copy <name> <file/dir> \n")),
             new TextComponent(TextComponent.fromLegacyText(
-                prefix + "§7/reformcloud maintenance\n")),
+                prefix + "§7/reformcloud maintenance <serverGroup> \n")),
             new TextComponent(TextComponent.fromLegacyText(
                 prefix + "§7/reformcloud whitelist <add/remove> <proxyGroup/--all> <name> \n")),
             new TextComponent(TextComponent.fromLegacyText(

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -253,7 +253,7 @@ public final class CommandReformCloud extends Command implements Serializable, T
                                 .getServerProcessManager().getAllRegisteredProxyProcesses().stream()
                                 .filter(proxyInfo -> proxyInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSender.sendMessage(TextComponent.fromLegacyText(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Player: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getProxyGroup().isMaintenance() + "§7 | Player: §e" + info
                                     .getOnline() + "§7/§e" + info.getProxyGroup().getMaxPlayers())));
                             commandSender.sendMessage(TextComponent.fromLegacyText(""));
                         } else {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -6,8 +6,12 @@ package systems.reformcloud.commands;
 
 import java.io.Serializable;
 import java.text.DecimalFormat;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.plugin.Command;
@@ -211,7 +215,7 @@ public final class CommandReformCloud extends Command implements Serializable, T
                         final ClientInfo clientInfo = ReformCloudAPIBungee.getInstance().getConnectedClient(e.getName());
                         commandSender.sendMessage(TextComponent.fromLegacyText(
                             "    - §e" + e.getName() + "§7 | Host: §e" + e.getIp() + "§7 | Memory-Usage: §e"
-                                + clientInfo.getUsedMemory() + "MB§7/§e" + clientInfo.getMaxMemory()
+                                + getMemoryOf(e.getName()) + "MB§7/§e" + clientInfo.getMaxMemory()
                                 + "MB§7 | Processors: §e" + clientInfo.getCpuCoresSystem()
                                 + "§7 | CPU-Usage: §e" + new DecimalFormat("##.###").format(clientInfo.getCpuUsage())
                                 + "%§7 | Started-Processes: §e" + (clientInfo.getStartedProxies().size()
@@ -467,5 +471,19 @@ public final class CommandReformCloud extends Command implements Serializable, T
             new TextComponent(TextComponent.fromLegacyText(
                 prefix + "§7/reformcloud version"))
         );
+    }
+
+    private long getMemoryOf(String client) {
+        AtomicLong atomicLong = new AtomicLong(0);
+        ReformCloudAPIBungee.getInstance().getAllRegisteredProxies()
+            .stream()
+            .filter(e -> e.getCloudProcess().getClient().equals(client))
+            .forEach(e -> atomicLong.addAndGet(e.getMaxMemory()));
+        ReformCloudAPIBungee.getInstance().getAllRegisteredServers()
+            .stream()
+            .filter(e -> e.getCloudProcess().getClient().equals(client))
+            .forEach(e -> atomicLong.addAndGet(e.getMaxMemory()));
+
+        return atomicLong.get();
     }
 }

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -271,7 +271,7 @@ public final class CommandReformCloud extends Command implements Serializable, T
                                 .getServerProcessManager().getAllRegisteredServerProcesses().stream()
                                 .filter(serverInfo -> serverInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSender.sendMessage(TextComponent.fromLegacyText(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | State: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getServerGroup().isMaintenance() + "§r | State: §e" + info
                                     .getServerState() + "§7 | Player: §e" + info.getOnline() + "§7/§e" + info
                                     .getServerGroup().getMaxPlayers())));
                             commandSender.sendMessage(TextComponent.fromLegacyText(""));

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/launcher/BungeecordBootstrap.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/launcher/BungeecordBootstrap.java
@@ -7,6 +7,8 @@ package systems.reformcloud.launcher;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.ResourceLeakDetector;
+import java.io.Serializable;
+import java.util.Arrays;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.plugin.Plugin;
 import systems.reformcloud.ReformCloudAPIBungee;
@@ -23,9 +25,6 @@ import systems.reformcloud.listener.CloudProxyPingListener;
 import systems.reformcloud.network.authentication.enums.AuthenticationType;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packets.PacketOutInternalProcessRemove;
-
-import java.io.Serializable;
-import java.util.Arrays;
 
 /**
  * @author _Klaro | Pasqual K. / created on 01.11.2018
@@ -54,7 +53,7 @@ public final class BungeecordBootstrap extends Plugin implements Serializable {
 
             @Override
             public String getVersion() {
-                return "4.1.36.Final";
+                return "4.1.37.Final";
             }
         });
         instance = this;

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/listener/CloudAddonsListener.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/listener/CloudAddonsListener.java
@@ -186,7 +186,7 @@ public final class CloudAddonsListener implements Listener {
                             BungeecordBootstrap.getInstance().getProxy().getOnlineCount()))
                         .replace("%max_players_global%", Integer.toString(
                             ReformCloudAPIBungee.getInstance().getGlobalMaxOnlineCount()))),
-                    event.getConnection().getVersion())
+                    1)
                 );
             }
         }

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/listener/CloudConnectListener.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/listener/CloudConnectListener.java
@@ -4,13 +4,21 @@
 
 package systems.reformcloud.listener;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.event.*;
+import net.md_5.bungee.api.event.LoginEvent;
+import net.md_5.bungee.api.event.PlayerDisconnectEvent;
+import net.md_5.bungee.api.event.ServerConnectEvent;
+import net.md_5.bungee.api.event.ServerKickEvent;
+import net.md_5.bungee.api.event.ServerSwitchEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 import systems.reformcloud.ReformCloudAPIBungee;
@@ -19,7 +27,12 @@ import systems.reformcloud.launcher.BungeecordBootstrap;
 import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.meta.proxy.settings.ProxySettings;
-import systems.reformcloud.network.packets.*;
+import systems.reformcloud.network.packets.PacketOutLoginPlayer;
+import systems.reformcloud.network.packets.PacketOutLogoutPlayer;
+import systems.reformcloud.network.packets.PacketOutProxyInfoUpdate;
+import systems.reformcloud.network.packets.PacketOutSendControllerConsoleMessage;
+import systems.reformcloud.network.packets.PacketOutUpdateOnlinePlayer;
+import systems.reformcloud.network.packets.PacketOutUpdatePermissionHolder;
 import systems.reformcloud.network.query.out.PacketOutQueryGetPermissionHolder;
 import systems.reformcloud.network.query.out.PacketOutQueryGetPlayer;
 import systems.reformcloud.player.implementations.OfflinePlayer;
@@ -27,11 +40,6 @@ import systems.reformcloud.player.implementations.OnlinePlayer;
 import systems.reformcloud.player.permissions.player.PermissionHolder;
 import systems.reformcloud.player.version.SpigotVersion;
 import systems.reformcloud.utility.TypeTokenAdaptor;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author _Klaro | Pasqual K. / created on 03.11.2018
@@ -52,6 +60,7 @@ public final class CloudConnectListener implements Listener {
             );
             if (serverInfo == null) {
                 event.setCancelled(true);
+                return;
             }
 
             event.getPlayer().setReconnectServer(BungeecordBootstrap.getInstance().getProxy()

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/listener/CloudConnectListener.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/listener/CloudConnectListener.java
@@ -179,7 +179,10 @@ public final class CloudConnectListener implements Listener {
 
         if (!started && proxyInfo.getProxyGroup().getAutoStart().isEnabled()
             && BungeecordBootstrap.getInstance().getProxy().getOnlineCount() >= proxyInfo
-            .getProxyGroup().getAutoStart().getPlayerMax()) {
+            .getProxyGroup().getAutoStart().getPlayerMax() &&
+            ReformCloudAPIBungee.getInstance().getAllRegisteredProxies(proxyInfo.getProxyGroup().getName())
+                .stream()
+                .noneMatch(e -> e.getOnline() < proxyInfo.getProxyGroup().getAutoStart().getPlayerMax())) {
             started = true;
             ReformCloudAPIBungee.getInstance().startProxy(proxyInfo.getProxyGroup());
             ReformCloudLibraryService.EXECUTOR_SERVICE.execute(() -> {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/network/packets/PacketOutGetOnlinePlayersResult.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/network/packets/PacketOutGetOnlinePlayersResult.java
@@ -1,0 +1,34 @@
+/*
+  Copyright © 2019 Pasqual K. | All rights reserved
+ */
+
+package systems.reformcloud.network.packets;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import systems.reformcloud.configurations.Configuration;
+import systems.reformcloud.launcher.BungeecordBootstrap;
+import systems.reformcloud.network.packet.Packet;
+import systems.reformcloud.utility.StringUtil;
+
+/**
+ * @author _Klaro | Pasqual K. / created on 02.07.2019
+ */
+
+public final class PacketOutGetOnlinePlayersResult extends Packet implements Serializable {
+
+    public PacketOutGetOnlinePlayersResult(UUID result) {
+        super(StringUtil.NULL, new Configuration().addValue("players",
+            convert()), result);
+    }
+
+    private static List<UUID> convert() {
+        List<UUID> out = new LinkedList<>();
+        BungeecordBootstrap.getInstance().getProxy().getPlayers()
+            .forEach(e -> out.add(e.getUniqueId()));
+        return out;
+    }
+
+}

--- a/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/network/query/in/PacketInQueryGetOnlinePlayers.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-bungee/src/main/java/systems/reformcloud/network/query/in/PacketInQueryGetOnlinePlayers.java
@@ -1,0 +1,27 @@
+/*
+  Copyright © 2019 Pasqual K. | All rights reserved
+ */
+
+package systems.reformcloud.network.query.in;
+
+import java.io.Serializable;
+import java.util.UUID;
+import systems.reformcloud.ReformCloudAPIBungee;
+import systems.reformcloud.configurations.Configuration;
+import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
+import systems.reformcloud.network.packets.PacketOutGetOnlinePlayersResult;
+
+/**
+ * @author _Klaro | Pasqual K. / created on 02.07.2019
+ */
+
+public final class PacketInQueryGetOnlinePlayers implements Serializable,
+    NetworkQueryInboundHandler {
+
+    @Override
+    public void handle(Configuration configuration, UUID resultID) {
+        ReformCloudAPIBungee.getInstance().getChannelHandler()
+            .sendPacketSynchronized(configuration.getStringValue("from"),
+                new PacketOutGetOnlinePlayersResult(resultID));
+    }
+}

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/pom.xml
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-api</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/pom.xml
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-api</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/ReformCloudAPISpigot.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/ReformCloudAPISpigot.java
@@ -5,29 +5,11 @@
 package systems.reformcloud;
 
 import com.google.gson.reflect.TypeToken;
-import java.io.Serializable;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.world.WorldLoadEvent;
-import systems.reformcloud.api.APIService;
-import systems.reformcloud.api.DefaultPermissionHelper;
-import systems.reformcloud.api.DefaultPlayerProvider;
-import systems.reformcloud.api.EventHandler;
-import systems.reformcloud.api.PlayerProvider;
-import systems.reformcloud.api.SaveAPImpl;
+import systems.reformcloud.api.*;
 import systems.reformcloud.api.permissions.PermissionHelper;
 import systems.reformcloud.api.save.SaveAPIService;
 import systems.reformcloud.configurations.Configuration;
@@ -60,42 +42,11 @@ import systems.reformcloud.network.NettySocketClient;
 import systems.reformcloud.network.abstracts.AbstractChannelHandler;
 import systems.reformcloud.network.api.event.NetworkEventHandler;
 import systems.reformcloud.network.channel.ChannelHandler;
-import systems.reformcloud.network.in.PacketInCreateSign;
-import systems.reformcloud.network.in.PacketInEnableDebug;
-import systems.reformcloud.network.in.PacketInEnableMobs;
-import systems.reformcloud.network.in.PacketInInitializeInternal;
-import systems.reformcloud.network.in.PacketInProcessAdd;
-import systems.reformcloud.network.in.PacketInProcessRemove;
-import systems.reformcloud.network.in.PacketInProxyInfoUpdate;
-import systems.reformcloud.network.in.PacketInRemoveSign;
-import systems.reformcloud.network.in.PacketInServerInfoUpdate;
-import systems.reformcloud.network.in.PacketInSignUpdate;
-import systems.reformcloud.network.in.PacketInSyncControllerTime;
-import systems.reformcloud.network.in.PacketInUpdateAll;
-import systems.reformcloud.network.in.PacketInUpdatePermissionCache;
-import systems.reformcloud.network.in.PacketInUpdatePermissionGroup;
-import systems.reformcloud.network.in.PacketInUpdatePermissionHolder;
+import systems.reformcloud.network.in.*;
 import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packet.PacketFuture;
-import systems.reformcloud.network.packets.PacketOutCreateClient;
-import systems.reformcloud.network.packets.PacketOutCreateProxyGroup;
-import systems.reformcloud.network.packets.PacketOutCreateServerGroup;
-import systems.reformcloud.network.packets.PacketOutCreateWebUser;
-import systems.reformcloud.network.packets.PacketOutDispatchConsoleCommand;
-import systems.reformcloud.network.packets.PacketOutExecuteCommand;
-import systems.reformcloud.network.packets.PacketOutExecuteCommandSilent;
-import systems.reformcloud.network.packets.PacketOutServerInfoUpdate;
-import systems.reformcloud.network.packets.PacketOutStartGameServer;
-import systems.reformcloud.network.packets.PacketOutStartProxy;
-import systems.reformcloud.network.packets.PacketOutStopProcess;
-import systems.reformcloud.network.packets.PacketOutUpdateOfflinePlayer;
-import systems.reformcloud.network.packets.PacketOutUpdateOnlinePlayer;
-import systems.reformcloud.network.packets.PacketOutUpdateProxyGroup;
-import systems.reformcloud.network.packets.PacketOutUpdateProxyInfo;
-import systems.reformcloud.network.packets.PacketOutUpdateServerGroup;
-import systems.reformcloud.network.packets.PacketOutUpdateServerInfo;
-import systems.reformcloud.network.packets.PacketOutUpdateServerTempStats;
+import systems.reformcloud.network.packets.*;
 import systems.reformcloud.network.query.in.PacketInQueryGetRuntimeInformation;
 import systems.reformcloud.network.query.out.PacketOutQueryGetOnlinePlayer;
 import systems.reformcloud.network.query.out.PacketOutQueryGetPlayer;
@@ -111,6 +62,13 @@ import systems.reformcloud.utility.TypeTokenAdaptor;
 import systems.reformcloud.utility.cloudsystem.EthernetAddress;
 import systems.reformcloud.utility.cloudsystem.InternalCloudNetwork;
 import systems.reformcloud.utility.defaults.DefaultCloudService;
+
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.12.2018
@@ -562,6 +520,36 @@ public final class ReformCloudAPISpigot implements Listener, APIService, Seriali
     public void updateServerGroup(ServerGroup serverGroup) {
         channelHandler.sendPacketSynchronized("ReformCloudController",
             new PacketOutUpdateServerGroup(serverGroup));
+    }
+
+    @Override
+    public void updateServerName(ServerInfo serverInfo, String newName) {
+        if (serverInfo == null || newName == null) {
+            return;
+        }
+
+        serverInfo.getCloudProcess().setName(newName);
+        this.updateServerInfo(serverInfo);
+    }
+
+    @Override
+    public void updateServerName(String serverName, String newName) {
+        this.updateServerName(this.getServerInfo(serverName), newName);
+    }
+
+    @Override
+    public void updateProxyName(ProxyInfo proxyInfo, String newName) {
+        if (proxyInfo == null || newName == null) {
+            return;
+        }
+
+        proxyInfo.getCloudProcess().setName(newName);
+        this.updateProxyInfo(proxyInfo);
+    }
+
+    @Override
+    public void updateProxyName(String proxyName, String newName) {
+        this.updateProxyName(this.getProxyInfo(proxyName), newName);
     }
 
     @Override

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/ReformCloudAPISpigot.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/ReformCloudAPISpigot.java
@@ -335,7 +335,8 @@ public final class ReformCloudAPISpigot implements Listener, APIService, Seriali
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -375,7 +376,8 @@ public final class ReformCloudAPISpigot implements Listener, APIService, Seriali
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            SpigotVersions.SPIGOT_1_8_8
+            SpigotVersions.SPIGOT_1_8_8,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -399,7 +401,8 @@ public final class ReformCloudAPISpigot implements Listener, APIService, Seriali
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/commands/CommandReformMobs.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/commands/CommandReformMobs.java
@@ -141,7 +141,7 @@ public final class CommandReformMobs implements Serializable, CommandExecutor, T
         }
 
         if (strings.length == 3 && strings[0].equalsIgnoreCase("create")) {
-            return Arrays.asList("_Klaro", "MrDoubleTime", "ReformCloud", commandSender.getName());
+            return Arrays.asList("_Klaro", "_MrVapor", "ByteException_", "ReformCloud", commandSender.getName());
         }
 
         if (strings.length == 4 && strings[0].equalsIgnoreCase("create")) {
@@ -151,7 +151,7 @@ public final class CommandReformMobs implements Serializable, CommandExecutor, T
         }
 
         if (strings.length == 5 && strings[0].equalsIgnoreCase("create")) {
-            return Arrays.asList("&6&lI'm cool", "&5&lMrDoubleTime is cool", "&7&lLobby");
+            return Arrays.asList("&6&lI'm cool", "&5&l_MrVapor is cool", "&7&lLobby");
         }
 
         if (strings.length == 2 && strings[0].equalsIgnoreCase("delete")) {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/launcher/SpigotBootstrap.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/launcher/SpigotBootstrap.java
@@ -10,6 +10,7 @@ import io.netty.util.ResourceLeakDetector;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.command.CommandMap;
 import org.bukkit.plugin.java.JavaPlugin;
 import systems.reformcloud.ReformCloudAPISpigot;
@@ -81,6 +82,7 @@ public final class SpigotBootstrap extends JavaPlugin implements Serializable {
 
     @Override
     public void onDisable() {
+        this.getServer().getWorlds().forEach(World::save);
         getServer().getScheduler().cancelTasks(this);
         getServer().getMessenger().unregisterOutgoingPluginChannel(this);
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/launcher/SpigotBootstrap.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/launcher/SpigotBootstrap.java
@@ -7,6 +7,8 @@ package systems.reformcloud.launcher;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.ResourceLeakDetector;
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandMap;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -20,9 +22,6 @@ import systems.reformcloud.network.authentication.enums.AuthenticationType;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packets.PacketOutInternalProcessRemove;
 import systems.reformcloud.permissions.ReflectionUtil;
-
-import java.io.Serializable;
-import java.lang.reflect.InvocationTargetException;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.12.2018
@@ -54,7 +53,7 @@ public final class SpigotBootstrap extends JavaPlugin implements Serializable {
 
             @Override
             public String getVersion() {
-                return "4.1.36.Final";
+                return "4.1.37.Final";
             }
         });
         this.start = System.currentTimeMillis();

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/listener/PlayerConnectListener.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/listener/PlayerConnectListener.java
@@ -48,18 +48,20 @@ public final class PlayerConnectListener implements Listener, Serializable {
 
     @EventHandler
     public void handle(final PlayerLoginEvent event) {
-        boolean ok = ReformCloudAPISpigot.getInstance().getChannelHandler().sendPacketQuerySync(
-            "ReformCloudController",
-            ReformCloudAPISpigot.getInstance().getServerInfo().getCloudProcess().getName(),
-            new PacketOutCheckPlayer(event.getPlayer().getUniqueId())
-        ).sendOnCurrentThread("ReformCloudController")
-            .syncUninterruptedly(500, TimeUnit.MILLISECONDS).getConfiguration()
-            .getBooleanValue("checked");
-        if (!ok) {
-            event.disallow(PlayerLoginEvent.Result.KICK_BANNED,
-                ReformCloudAPISpigot.getInstance().getInternalCloudNetwork()
-                    .getMessage("internal-api-spigot-connect-only-proxy"));
-            return;
+        if (ReformCloudAPISpigot.getInstance().getServerInfo().getServerGroup().isOnlyProxyJoin()) {
+            boolean ok = ReformCloudAPISpigot.getInstance().getChannelHandler().sendPacketQuerySync(
+                "ReformCloudController",
+                ReformCloudAPISpigot.getInstance().getServerInfo().getCloudProcess().getName(),
+                new PacketOutCheckPlayer(event.getPlayer().getUniqueId())
+            ).sendOnCurrentThread("ReformCloudController")
+                .syncUninterruptedly(500, TimeUnit.MILLISECONDS).getConfiguration()
+                .getBooleanValue("checked");
+            if (!ok) {
+                event.disallow(PlayerLoginEvent.Result.KICK_BANNED,
+                    ReformCloudAPISpigot.getInstance().getInternalCloudNetwork()
+                        .getMessage("internal-api-spigot-connect-only-proxy"));
+                return;
+            }
         }
 
         if (ReformCloudAPISpigot.getInstance().getPermissionCache() != null) {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/listener/PlayerConnectListener.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/listener/PlayerConnectListener.java
@@ -153,9 +153,10 @@ public final class PlayerConnectListener implements Listener, Serializable {
         ReformCloudAPISpigot.getInstance().getChannelHandler()
             .sendPacketSynchronized("ReformCloudController",
                 new PacketOutServerInfoUpdate(serverInfo));
-        if (!started && serverInfo.getServerGroup().getAutoStart().isEnabled()
-            && Bukkit.getServer().getOnlinePlayers().size() >= serverInfo.getServerGroup()
-            .getAutoStart().getPlayerMax()) {
+        if (!started && serverInfo.getServerGroup().getAutoStart().isEnabled() &&
+            ReformCloudAPISpigot.getInstance().getAllRegisteredServers(serverInfo.getServerGroup().getName())
+                .stream()
+                .noneMatch(e -> e.getOnline() < serverInfo.getServerGroup().getAutoStart().getPlayerMax())) {
             started = true;
             ReformCloudAPISpigot.getInstance().startQueuedProcess(serverInfo.getServerGroup());
             SpigotBootstrap.getInstance().getServer().getScheduler()

--- a/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/updater/ServerListUpdater.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-spigot/src/main/java/systems/reformcloud/updater/ServerListUpdater.java
@@ -44,7 +44,7 @@ public final class ServerListUpdater extends Thread implements Serializable {
                     );
                     Bukkit.getServer().getPluginManager().callEvent(serverListPingEvent);
                     if (!serverListPingEvent.getMotd().equals(motd)) {
-                        ReformCloudAPISpigot.getInstance().getServerInfo().setMotd(motd);
+                        ReformCloudAPISpigot.getInstance().getServerInfo().setMotd(serverListPingEvent.getMotd());
 
                         if (serverListPingEvent.getMotd().toLowerCase().contains("reformcloud_hidden")
                             && !ReformCloudAPISpigot.getInstance().getServerInfo().getServerState().equals(ServerState.HIDDEN)) {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/pom.xml
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-api</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/pom.xml
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-api</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/ReformCloudAPIVelocity.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/ReformCloudAPIVelocity.java
@@ -102,6 +102,7 @@ import systems.reformcloud.network.packets.PacketOutUpdateProxyGroup;
 import systems.reformcloud.network.packets.PacketOutUpdateProxyInfo;
 import systems.reformcloud.network.packets.PacketOutUpdateServerGroup;
 import systems.reformcloud.network.packets.PacketOutUpdateServerInfo;
+import systems.reformcloud.network.query.in.PacketInQueryGetOnlinePlayers;
 import systems.reformcloud.network.query.in.PacketInQueryGetRuntimeInformation;
 import systems.reformcloud.network.query.out.PacketOutQueryGetOnlinePlayer;
 import systems.reformcloud.network.query.out.PacketOutQueryGetPlayer;
@@ -205,6 +206,7 @@ public final class ReformCloudAPIVelocity implements Serializable, APIService {
             .registerHandler("UpdateIngameCommands", new PacketInUpdateIngameCommands())
             .registerHandler("UpdatePermissionHolder", new PacketInUpdatePermissionHolder())
             .registerQueryHandler("GetRuntimeInformation", new PacketInQueryGetRuntimeInformation())
+            .registerQueryHandler("GetOnlinePlayers", new PacketInQueryGetOnlinePlayers())
             .registerHandler("UpdatePermissionGroup", new PacketInUpdatePermissionGroup())
             .registerHandler("ServerInfoUpdate", new PacketInServerInfoUpdate());
 

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/ReformCloudAPIVelocity.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/ReformCloudAPIVelocity.java
@@ -8,28 +8,8 @@ import com.google.common.base.Enums;
 import com.google.gson.reflect.TypeToken;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
-import java.io.Serializable;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import net.kyori.text.TextComponent;
-import systems.reformcloud.api.APIService;
-import systems.reformcloud.api.DefaultPermissionHelper;
-import systems.reformcloud.api.DefaultPlayerProvider;
-import systems.reformcloud.api.EventHandler;
-import systems.reformcloud.api.PlayerProvider;
-import systems.reformcloud.api.SaveAPIImpl;
+import systems.reformcloud.api.*;
 import systems.reformcloud.api.permissions.PermissionHelper;
 import systems.reformcloud.api.save.SaveAPIService;
 import systems.reformcloud.bootstrap.VelocityBootstrap;
@@ -65,43 +45,11 @@ import systems.reformcloud.network.NettySocketClient;
 import systems.reformcloud.network.abstracts.AbstractChannelHandler;
 import systems.reformcloud.network.api.event.NetworkEventAdapter;
 import systems.reformcloud.network.channel.ChannelHandler;
-import systems.reformcloud.network.in.PacketInConnectPlayer;
-import systems.reformcloud.network.in.PacketInDisableIcons;
-import systems.reformcloud.network.in.PacketInEnableDebug;
-import systems.reformcloud.network.in.PacketInEnableIcons;
-import systems.reformcloud.network.in.PacketInInitializeInternal;
-import systems.reformcloud.network.in.PacketInKickPlayer;
-import systems.reformcloud.network.in.PacketInProcessAdd;
-import systems.reformcloud.network.in.PacketInProcessRemove;
-import systems.reformcloud.network.in.PacketInProxyInfoUpdate;
-import systems.reformcloud.network.in.PacketInSendPlayerMessage;
-import systems.reformcloud.network.in.PacketInServerInfoUpdate;
-import systems.reformcloud.network.in.PacketInSyncControllerTime;
-import systems.reformcloud.network.in.PacketInUpdateAll;
-import systems.reformcloud.network.in.PacketInUpdateIngameCommands;
-import systems.reformcloud.network.in.PacketInUpdatePermissionCache;
-import systems.reformcloud.network.in.PacketInUpdatePermissionGroup;
-import systems.reformcloud.network.in.PacketInUpdatePermissionHolder;
-import systems.reformcloud.network.in.PacketInUpdateProxySettings;
+import systems.reformcloud.network.in.*;
 import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packet.PacketFuture;
-import systems.reformcloud.network.packets.PacketOutCreateClient;
-import systems.reformcloud.network.packets.PacketOutCreateProxyGroup;
-import systems.reformcloud.network.packets.PacketOutCreateServerGroup;
-import systems.reformcloud.network.packets.PacketOutCreateWebUser;
-import systems.reformcloud.network.packets.PacketOutDispatchConsoleCommand;
-import systems.reformcloud.network.packets.PacketOutExecuteCommand;
-import systems.reformcloud.network.packets.PacketOutExecuteCommandSilent;
-import systems.reformcloud.network.packets.PacketOutStartGameServer;
-import systems.reformcloud.network.packets.PacketOutStartProxy;
-import systems.reformcloud.network.packets.PacketOutStopProcess;
-import systems.reformcloud.network.packets.PacketOutUpdateOfflinePlayer;
-import systems.reformcloud.network.packets.PacketOutUpdateOnlinePlayer;
-import systems.reformcloud.network.packets.PacketOutUpdateProxyGroup;
-import systems.reformcloud.network.packets.PacketOutUpdateProxyInfo;
-import systems.reformcloud.network.packets.PacketOutUpdateServerGroup;
-import systems.reformcloud.network.packets.PacketOutUpdateServerInfo;
+import systems.reformcloud.network.packets.*;
 import systems.reformcloud.network.query.in.PacketInQueryGetOnlinePlayers;
 import systems.reformcloud.network.query.in.PacketInQueryGetRuntimeInformation;
 import systems.reformcloud.network.query.out.PacketOutQueryGetOnlinePlayer;
@@ -119,6 +67,13 @@ import systems.reformcloud.utility.TypeTokenAdaptor;
 import systems.reformcloud.utility.cloudsystem.EthernetAddress;
 import systems.reformcloud.utility.cloudsystem.InternalCloudNetwork;
 import systems.reformcloud.utility.defaults.DefaultCloudService;
+
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * @author _Klaro | Pasqual K. / created on 24.03.2019
@@ -566,6 +521,36 @@ public final class ReformCloudAPIVelocity implements Serializable, APIService {
     public void updateServerGroup(ServerGroup serverGroup) {
         channelHandler.sendPacketSynchronized("ReformCloudController",
             new PacketOutUpdateServerGroup(serverGroup));
+    }
+
+    @Override
+    public void updateServerName(ServerInfo serverInfo, String newName) {
+        if (serverInfo == null || newName == null) {
+            return;
+        }
+
+        serverInfo.getCloudProcess().setName(newName);
+        this.updateServerInfo(serverInfo);
+    }
+
+    @Override
+    public void updateServerName(String serverName, String newName) {
+        this.updateServerName(this.getServerInfo(serverName), newName);
+    }
+
+    @Override
+    public void updateProxyName(ProxyInfo proxyInfo, String newName) {
+        if (proxyInfo == null || newName == null) {
+            return;
+        }
+
+        proxyInfo.getCloudProcess().setName(newName);
+        this.updateProxyInfo(proxyInfo);
+    }
+
+    @Override
+    public void updateProxyName(String proxyName, String newName) {
+        this.updateProxyName(this.getProxyInfo(proxyName), newName);
     }
 
     @Override

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/ReformCloudAPIVelocity.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/ReformCloudAPIVelocity.java
@@ -339,7 +339,8 @@ public final class ReformCloudAPIVelocity implements Serializable, APIService {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -379,7 +380,8 @@ public final class ReformCloudAPIVelocity implements Serializable, APIService {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            SpigotVersions.SPIGOT_1_8_8
+            SpigotVersions.SPIGOT_1_8_8,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -403,7 +405,8 @@ public final class ReformCloudAPIVelocity implements Serializable, APIService {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/bootstrap/VelocityBootstrap.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/bootstrap/VelocityBootstrap.java
@@ -70,7 +70,7 @@ public final class VelocityBootstrap implements Serializable {
 
             @Override
             public String getVersion() {
-                return "4.1.36.Final";
+                return "4.1.37.Final";
             }
         });
         instance = this;

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -256,7 +256,7 @@ public final class CommandReformCloud implements Command {
                                 .getServerProcessManager().getAllRegisteredServerProcesses().stream()
                                 .filter(serverInfo -> serverInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSource.sendMessage(TextComponent.of(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | State: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getServerGroup().isMaintenance() + "§r | State: §e" + info
                                     .getServerState() + "§7 | Player: §e" + info.getOnline() + "§7/§e" + info
                                     .getServerGroup().getMaxPlayers())));
                             commandSource.sendMessage(TextComponent.of(""));

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -238,7 +238,7 @@ public final class CommandReformCloud implements Command {
                                 .getServerProcessManager().getAllRegisteredProxyProcesses().stream()
                                 .filter(proxyInfo -> proxyInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSource.sendMessage(TextComponent.of(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getProxyGroup().isMaintenance() + "§7 | Player: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Player: §e" + info
                                     .getOnline() + "§7/§e" + info.getProxyGroup().getMaxPlayers())));
                             commandSource.sendMessage(TextComponent.of(""));
                         } else {
@@ -256,7 +256,7 @@ public final class CommandReformCloud implements Command {
                                 .getServerProcessManager().getAllRegisteredServerProcesses().stream()
                                 .filter(serverInfo -> serverInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSource.sendMessage(TextComponent.of(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getServerGroup().isMaintenance() + "§r | State: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | State: §e" + info
                                     .getServerState() + "§7 | Player: §e" + info.getOnline() + "§7/§e" + info
                                     .getServerGroup().getMaxPlayers())));
                             commandSource.sendMessage(TextComponent.of(""));

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -6,12 +6,12 @@ package systems.reformcloud.commands;
 
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
-
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import net.kyori.text.TextComponent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.optional.qual.MaybePresent;
@@ -200,7 +200,7 @@ public final class CommandReformCloud implements Command {
                         final ClientInfo clientInfo = ReformCloudAPIVelocity.getInstance().getConnectedClient(e.getName());
                         commandSource.sendMessage(TextComponent.of(
                             "    - §e" + e.getName() + "§7 | Host: §e" + e.getIp() + "§7 | Memory-Usage: §e"
-                                + clientInfo.getUsedMemory() + "MB§7/§e" + clientInfo.getMaxMemory()
+                                + getMemoryOf(e.getName()) + "MB§7/§e" + clientInfo.getMaxMemory()
                                 + "MB§7 | Processors: §e" + clientInfo.getCpuCoresSystem()
                                 + "§7 | CPU-Usage: §e" + new DecimalFormat("##.###").format(clientInfo.getCpuUsage())
                                 + "%§7 | Started-Processes: §e" + (clientInfo.getStartedProxies().size()
@@ -452,5 +452,19 @@ public final class CommandReformCloud implements Command {
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud list <server/proxy> <group-name> \n"));
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud reload \n"));
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud version"));
+    }
+
+    private long getMemoryOf(String client) {
+        AtomicLong atomicLong = new AtomicLong(0);
+        ReformCloudAPIVelocity.getInstance().getAllRegisteredProxies()
+            .stream()
+            .filter(e -> e.getCloudProcess().getClient().equals(client))
+            .forEach(e -> atomicLong.addAndGet(e.getMaxMemory()));
+        ReformCloudAPIVelocity.getInstance().getAllRegisteredServers()
+            .stream()
+            .filter(e -> e.getCloudProcess().getClient().equals(client))
+            .forEach(e -> atomicLong.addAndGet(e.getMaxMemory()));
+
+        return atomicLong.get();
     }
 }

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -238,7 +238,7 @@ public final class CommandReformCloud implements Command {
                                 .getServerProcessManager().getAllRegisteredProxyProcesses().stream()
                                 .filter(proxyInfo -> proxyInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSource.sendMessage(TextComponent.of(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Player: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §" + info.getProxyGroup().isMaintenance() + "§7 | Player: §e" + info
                                     .getOnline() + "§7/§e" + info.getProxyGroup().getMaxPlayers())));
                             commandSource.sendMessage(TextComponent.of(""));
                         } else {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -238,7 +238,7 @@ public final class CommandReformCloud implements Command {
                                 .getServerProcessManager().getAllRegisteredProxyProcesses().stream()
                                 .filter(proxyInfo -> proxyInfo.getCloudProcess().getClient()
                                     .equals(e.getName())).forEach(info -> commandSource.sendMessage(TextComponent.of(
-                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §" + info.getProxyGroup().isMaintenance() + "§7 | Player: §e" + info
+                                "    - §e" + info.getCloudProcess().getName() + "§7 | Maintenance: §e" + info.getProxyGroup().isMaintenance() + "§7 | Player: §e" + info
                                     .getOnline() + "§7/§e" + info.getProxyGroup().getMaxPlayers())));
                             commandSource.sendMessage(TextComponent.of(""));
                         } else {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/commands/CommandReformCloud.java
@@ -22,6 +22,7 @@ import systems.reformcloud.meta.info.ClientInfo;
 import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.meta.proxy.ProxyGroup;
+import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.network.packets.PacketOutDispatchConsoleCommand;
 import systems.reformcloud.utility.StringUtil;
 
@@ -67,17 +68,35 @@ public final class CommandReformCloud implements Command {
         }
 
         if (strings[0].equalsIgnoreCase("maintenance")) {
-            ProxyGroup proxyGroup =
-                ReformCloudAPIVelocity.getInstance().getProxyInfo().getProxyGroup();
-            ReformCloudAPIVelocity.getInstance().dispatchConsoleCommand(
-                "asg proxygroup " + proxyGroup.getName() +
-                    " maintenance " + (proxyGroup.isMaintenance() ? "false --update" :
-                    "true --update")
-            );
-            commandSource.sendMessage(TextComponent.of(
-                ReformCloudAPIVelocity.getInstance().getInternalCloudNetwork()
-                    .getMessage("internal-api-bungee-command-send-controller")
-            ));
+            if (strings.length != 2) {
+                ProxyGroup proxyGroup =
+                    ReformCloudAPIVelocity.getInstance().getProxyInfo().getProxyGroup();
+                ReformCloudAPIVelocity.getInstance().dispatchConsoleCommand(
+                    "asg proxygroup " + proxyGroup.getName() +
+                        " maintenance " + (proxyGroup.isMaintenance() ? "false --update" :
+                        "true --update")
+                );
+                commandSource.sendMessage(TextComponent.of(
+                    ReformCloudAPIVelocity.getInstance().getInternalCloudNetwork()
+                        .getMessage("internal-api-bungee-command-send-controller")
+                ));
+                return;
+            }
+            ServerGroup serverGroup =
+                ReformCloudAPIVelocity.getInstance().getServerGroup(strings[1]);
+            if (serverGroup != null) {
+                ReformCloudAPIVelocity.getInstance().dispatchConsoleCommand(
+                    "asg servergroup " + serverGroup.getName() +
+                        " maintenance " + (serverGroup.isMaintenance() ? "false" : "true") +
+                        " --update"
+                );
+                commandSource.sendMessage(TextComponent.of(
+                    ReformCloudAPIVelocity.getInstance().getInternalCloudNetwork()
+                        .getMessage("internal-api-bungee-command-send-controller")
+                ));
+                return;
+            }
+            commandSource.sendMessage(TextComponent.of(prefix + "§cThe servergroup doesn't exists"));
             return;
         }
 
@@ -327,6 +346,10 @@ public final class CommandReformCloud implements Command {
             return new LinkedList<>();
         }
 
+        if (strings.length == 2 && strings[0].equalsIgnoreCase("maintenance")) {
+            return registeredServerGroups();
+        }
+
         if (strings.length == 2 && strings[0].equalsIgnoreCase("copy")) {
             return registered();
         }
@@ -445,7 +468,7 @@ public final class CommandReformCloud implements Command {
 
     private void sendHelp(CommandSource commandSource, String prefix) {
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud copy <name> <file/dir> \n"));
-        commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud maintenance \n"));
+        commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud maintenance <serverGroup> \n"));
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud whitelist <add/remove> <proxyGroup/--all> <name> \n"));
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud execute <server/proxy> <name> <command> \n"));
         commandSource.sendMessage(TextComponent.of(prefix + "§7/reformcloud process <start/stop> <group/name> \n"));

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/listener/CloudConnectListener.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/listener/CloudConnectListener.java
@@ -117,7 +117,10 @@ public final class CloudConnectListener {
 
         if (!started && proxyInfo.getProxyGroup().getAutoStart().isEnabled()
             && VelocityBootstrap.getInstance().getProxy().getPlayerCount() >= proxyInfo
-            .getProxyGroup().getAutoStart().getPlayerMax()) {
+            .getProxyGroup().getAutoStart().getPlayerMax() &&
+            ReformCloudAPIVelocity.getInstance().getAllRegisteredProxies(proxyInfo.getProxyGroup().getName())
+                .stream()
+                .noneMatch(e -> e.getOnline() < proxyInfo.getProxyGroup().getAutoStart().getPlayerMax())) {
             started = true;
             ReformCloudAPIVelocity.getInstance().startProxy(proxyInfo.getProxyGroup());
             ReformCloudLibraryService.EXECUTOR_SERVICE.execute(() -> {

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/network/packets/PacketOutGetOnlinePlayersResult.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/network/packets/PacketOutGetOnlinePlayersResult.java
@@ -1,0 +1,34 @@
+/*
+  Copyright © 2019 Pasqual K. | All rights reserved
+ */
+
+package systems.reformcloud.network.packets;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import systems.reformcloud.bootstrap.VelocityBootstrap;
+import systems.reformcloud.configurations.Configuration;
+import systems.reformcloud.network.packet.Packet;
+import systems.reformcloud.utility.StringUtil;
+
+/**
+ * @author _Klaro | Pasqual K. / created on 02.07.2019
+ */
+
+public final class PacketOutGetOnlinePlayersResult extends Packet implements Serializable {
+
+    public PacketOutGetOnlinePlayersResult(UUID result) {
+        super(StringUtil.NULL, new Configuration().addValue("players",
+            convert()), result);
+    }
+
+    private static List<UUID> convert() {
+        List<UUID> out = new LinkedList<>();
+        VelocityBootstrap.getInstance().getProxy().getAllPlayers()
+            .forEach(e -> out.add(e.getUniqueId()));
+        return out;
+    }
+
+}

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/network/query/in/PacketInQueryGetOnlinePlayers.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/network/query/in/PacketInQueryGetOnlinePlayers.java
@@ -1,0 +1,27 @@
+/*
+  Copyright © 2019 Pasqual K. | All rights reserved
+ */
+
+package systems.reformcloud.network.query.in;
+
+import java.io.Serializable;
+import java.util.UUID;
+import systems.reformcloud.ReformCloudAPIVelocity;
+import systems.reformcloud.configurations.Configuration;
+import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
+import systems.reformcloud.network.packets.PacketOutGetOnlinePlayersResult;
+
+/**
+ * @author _Klaro | Pasqual K. / created on 02.07.2019
+ */
+
+public final class PacketInQueryGetOnlinePlayers implements Serializable,
+    NetworkQueryInboundHandler {
+
+    @Override
+    public void handle(Configuration configuration, UUID resultID) {
+        ReformCloudAPIVelocity.getInstance().getChannelHandler()
+            .sendPacketSynchronized(configuration.getStringValue("from"),
+                new PacketOutGetOnlinePlayersResult(resultID));
+    }
+}

--- a/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/permissions/VelocityPermissionFunctionAdapter.java
+++ b/reformcloud-global/reformcloud-api/reformcloud-api-velocity/src/main/java/systems/reformcloud/permissions/VelocityPermissionFunctionAdapter.java
@@ -38,7 +38,9 @@ public final class VelocityPermissionFunctionAdapter implements Serializable, Pe
     }
 
     private UUID permissionSubject;
+
     private PermissionHolder permissionHolder;
+
     private List<PermissionGroup> permissionGroups;
 
     @Override

--- a/reformcloud-global/reformcloud-client/pom.xml
+++ b/reformcloud-global/reformcloud-client/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-yaml</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -53,7 +53,7 @@
     <parent>
         <artifactId>reformcloud-global</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 
     <build>

--- a/reformcloud-global/reformcloud-client/pom.xml
+++ b/reformcloud-global/reformcloud-client/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-yaml</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -53,7 +53,7 @@
     <parent>
         <artifactId>reformcloud-global</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 
     <build>

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/ReformCloudClient.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/ReformCloudClient.java
@@ -20,6 +20,7 @@ import systems.reformcloud.event.events.ReloadDoneEvent;
 import systems.reformcloud.event.events.StartedEvent;
 import systems.reformcloud.exceptions.InstanceAlreadyExistsException;
 import systems.reformcloud.exceptions.LoadException;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.logging.ColouredConsoleProvider;
 import systems.reformcloud.meta.Template;
 import systems.reformcloud.meta.auto.start.AutoStart;
@@ -75,7 +76,7 @@ import systems.reformcloud.utility.files.FileUtils;
 import systems.reformcloud.utility.parameters.ParameterManager;
 import systems.reformcloud.utility.runtime.Reload;
 import systems.reformcloud.utility.runtime.Shutdown;
-import systems.reformcloud.utility.threading.TaskScheduler;
+import systems.reformcloud.utility.threading.AbstractTaskScheduler;
 import systems.reformcloud.versioneering.VersionController;
 
 import java.io.IOException;
@@ -101,9 +102,9 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
 
     private static ReformCloudClient instance;
 
-    private ColouredConsoleProvider colouredConsoleProvider;
+    private AbstractLoggerProvider colouredConsoleProvider;
 
-    private CommandManager commandManager;
+    private AbstractCommandManager commandManager;
 
     private boolean ssl;
 
@@ -117,7 +118,7 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
 
     private InternalCloudNetwork internalCloudNetwork = new InternalCloudNetwork();
 
-    private final TaskScheduler taskScheduler;
+    private final AbstractTaskScheduler taskScheduler;
 
     private final AbstractChannelHandler channelHandler;
 
@@ -1343,11 +1344,11 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
         System.exit(ExitUtil.STOPPED_SUCESS);
     }
 
-    public ColouredConsoleProvider getColouredConsoleProvider() {
+    public AbstractLoggerProvider getColouredConsoleProvider() {
         return this.colouredConsoleProvider;
     }
 
-    public CommandManager getCommandManager() {
+    public AbstractCommandManager getCommandManager() {
         return this.commandManager;
     }
 
@@ -1375,7 +1376,7 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
         return this.internalCloudNetwork;
     }
 
-    public TaskScheduler getTaskScheduler() {
+    public AbstractTaskScheduler getTaskScheduler() {
         return this.taskScheduler;
     }
 

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/ReformCloudClient.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/ReformCloudClient.java
@@ -6,41 +6,11 @@ package systems.reformcloud;
 
 import com.google.gson.reflect.TypeToken;
 import io.netty.channel.ChannelFutureListener;
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 import systems.reformcloud.addons.AddonParallelLoader;
-import systems.reformcloud.api.APIService;
-import systems.reformcloud.api.DefaultPlayerProvider;
-import systems.reformcloud.api.EventAdapter;
-import systems.reformcloud.api.PlayerProvider;
-import systems.reformcloud.api.SaveAPIImpl;
+import systems.reformcloud.api.*;
 import systems.reformcloud.api.permissions.PermissionHelper;
 import systems.reformcloud.api.save.SaveAPIService;
-import systems.reformcloud.commands.CommandAddons;
-import systems.reformcloud.commands.CommandClear;
-import systems.reformcloud.commands.CommandExit;
-import systems.reformcloud.commands.CommandHelp;
-import systems.reformcloud.commands.CommandManager;
-import systems.reformcloud.commands.CommandReload;
-import systems.reformcloud.commands.CommandUpdate;
-import systems.reformcloud.commands.CommandVersion;
+import systems.reformcloud.commands.*;
 import systems.reformcloud.configuration.CloudConfiguration;
 import systems.reformcloud.configurations.Configuration;
 import systems.reformcloud.cryptic.StringEncrypt;
@@ -76,61 +46,14 @@ import systems.reformcloud.network.interfaces.NetworkInboundHandler;
 import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packet.PacketFuture;
-import systems.reformcloud.network.packets.in.PacketInCopyServerIntoTemplate;
-import systems.reformcloud.network.packets.in.PacketInDeleteTemplate;
-import systems.reformcloud.network.packets.in.PacketInDeployServer;
-import systems.reformcloud.network.packets.in.PacketInDisableBackup;
-import systems.reformcloud.network.packets.in.PacketInDisableProperties;
-import systems.reformcloud.network.packets.in.PacketInEnableBackup;
-import systems.reformcloud.network.packets.in.PacketInEnableDebug;
-import systems.reformcloud.network.packets.in.PacketInEnableProperties;
-import systems.reformcloud.network.packets.in.PacketInExecuteClientCommand;
-import systems.reformcloud.network.packets.in.PacketInExecuteCommand;
-import systems.reformcloud.network.packets.in.PacketInGetClientProcessQueue;
-import systems.reformcloud.network.packets.in.PacketInGetControllerTemplateResult;
-import systems.reformcloud.network.packets.in.PacketInInitializeInternal;
-import systems.reformcloud.network.packets.in.PacketInParameterUpdate;
-import systems.reformcloud.network.packets.in.PacketInRemoveProxyProcessQueue;
-import systems.reformcloud.network.packets.in.PacketInRemoveServerQueueProcess;
-import systems.reformcloud.network.packets.in.PacketInServerInfoUpdate;
-import systems.reformcloud.network.packets.in.PacketInStartGameServer;
-import systems.reformcloud.network.packets.in.PacketInStartProxy;
-import systems.reformcloud.network.packets.in.PacketInStopProcess;
-import systems.reformcloud.network.packets.in.PacketInTemplateDeployReady;
-import systems.reformcloud.network.packets.in.PacketInUpdateAll;
-import systems.reformcloud.network.packets.in.PacketInUpdateClientAddon;
-import systems.reformcloud.network.packets.in.PacketInUpdateClientFromURL;
-import systems.reformcloud.network.packets.in.PacketInUpdateClientSetting;
-import systems.reformcloud.network.packets.in.PacketInUpdateProxyGroupPlugin;
-import systems.reformcloud.network.packets.in.PacketInUpdateProxyGroupPluginTemplate;
-import systems.reformcloud.network.packets.in.PacketInUpdateServerGroupPluginTemplate;
-import systems.reformcloud.network.packets.in.PacketInUpdateSeverGroupPlugin;
-import systems.reformcloud.network.packets.in.PacketInUploadLog;
-import systems.reformcloud.network.packets.out.PacketOutCreateClient;
-import systems.reformcloud.network.packets.out.PacketOutCreateProxyGroup;
-import systems.reformcloud.network.packets.out.PacketOutCreateServerGroup;
-import systems.reformcloud.network.packets.out.PacketOutCreateWebUser;
-import systems.reformcloud.network.packets.out.PacketOutDispatchConsoleCommand;
-import systems.reformcloud.network.packets.out.PacketOutExecuteCommandSilent;
-import systems.reformcloud.network.packets.out.PacketOutStartGameServer;
-import systems.reformcloud.network.packets.out.PacketOutStartProxy;
-import systems.reformcloud.network.packets.out.PacketOutStopProcess;
-import systems.reformcloud.network.packets.out.PacketOutUpdateOfflinePlayer;
-import systems.reformcloud.network.packets.out.PacketOutUpdateOnlinePlayer;
-import systems.reformcloud.network.packets.out.PacketOutUpdateProxyGroup;
-import systems.reformcloud.network.packets.out.PacketOutUpdateProxyInfo;
-import systems.reformcloud.network.packets.out.PacketOutUpdateServerGroup;
-import systems.reformcloud.network.packets.out.PacketOutUpdateServerInfo;
+import systems.reformcloud.network.packets.in.*;
+import systems.reformcloud.network.packets.out.*;
 import systems.reformcloud.network.packets.query.in.PacketInQueryGetRuntimeInformation;
 import systems.reformcloud.network.packets.query.out.PacketOutQueryGetOnlinePlayer;
 import systems.reformcloud.network.packets.query.out.PacketOutQueryGetPlayer;
 import systems.reformcloud.network.packets.query.out.PacketOutQueryGetRuntimeInformation;
 import systems.reformcloud.network.packets.query.out.PacketOutQueryStartQueuedProcess;
-import systems.reformcloud.network.packets.sync.in.PacketInSyncControllerTime;
-import systems.reformcloud.network.packets.sync.in.PacketInSyncScreenDisable;
-import systems.reformcloud.network.packets.sync.in.PacketInSyncScreenJoin;
-import systems.reformcloud.network.packets.sync.in.PacketInSyncStandby;
-import systems.reformcloud.network.packets.sync.in.PacketInSyncUpdateClient;
+import systems.reformcloud.network.packets.sync.in.*;
 import systems.reformcloud.network.packets.sync.out.PacketOutSyncClientDisconnects;
 import systems.reformcloud.network.packets.sync.out.PacketOutSyncClientUpdateSuccess;
 import systems.reformcloud.player.implementations.OfflinePlayer;
@@ -154,6 +77,19 @@ import systems.reformcloud.utility.runtime.Reload;
 import systems.reformcloud.utility.runtime.Shutdown;
 import systems.reformcloud.utility.threading.TaskScheduler;
 import systems.reformcloud.versioneering.VersionController;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 /**
  * @author _Klaro | Pasqual K. / created on 23.10.2018
@@ -842,6 +778,36 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
     public void updateServerGroup(ServerGroup serverGroup) {
         channelHandler.sendPacketSynchronized("ReformCloudController",
             new PacketOutUpdateServerGroup(serverGroup));
+    }
+
+    @Override
+    public void updateServerName(ServerInfo serverInfo, String newName) {
+        if (serverInfo == null || newName == null) {
+            return;
+        }
+
+        serverInfo.getCloudProcess().setName(newName);
+        this.updateServerInfo(serverInfo);
+    }
+
+    @Override
+    public void updateServerName(String serverName, String newName) {
+        this.updateServerName(this.getServerInfo(serverName), newName);
+    }
+
+    @Override
+    public void updateProxyName(ProxyInfo proxyInfo, String newName) {
+        if (proxyInfo == null || newName == null) {
+            return;
+        }
+
+        proxyInfo.getCloudProcess().setName(newName);
+        this.updateProxyInfo(proxyInfo);
+    }
+
+    @Override
+    public void updateProxyName(String proxyName, String newName) {
+        this.updateProxyName(this.getProxyInfo(proxyName), newName);
     }
 
     @Override

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/ReformCloudClient.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/ReformCloudClient.java
@@ -615,7 +615,8 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
             new AutoStart(true, 510, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -655,7 +656,8 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            SpigotVersions.SPIGOT_1_8_8
+            SpigotVersions.SPIGOT_1_8_8,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -679,7 +681,8 @@ public final class ReformCloudClient implements Serializable, Shutdown, Reload, 
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/commands/CommandClear.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/commands/CommandClear.java
@@ -26,7 +26,7 @@ public final class CommandClear extends Command implements Serializable {
     @Override
     public void executeCommand(CommandSender commandSender, String[] args) {
         try {
-            ReformCloudClient.getInstance().getColouredConsoleProvider().getConsoleReader().clearScreen();
+            ReformCloudClient.getInstance().getColouredConsoleProvider().consoleReader().clearScreen();
         } catch (final IOException ex) {
             StringUtil
                 .printError(ReformCloudLibraryServiceProvider.getInstance().getColouredConsoleProvider(),

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/commands/CommandHelp.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/commands/CommandHelp.java
@@ -36,16 +36,16 @@ public final class CommandHelp extends Command implements Serializable {
 
         ReformCloudClient.getInstance().getColouredConsoleProvider().emptyLine();
 
-        commandSender.sendMessage("Ram: " + decimalFormat.format(
+        commandSender.sendMessage("Ram: §e" + decimalFormat.format(
             ReformCloudLibraryService.bytesToMB(ReformCloudLibraryService.usedMemorySystem()))
             + "MB/" + decimalFormat.format(
             ReformCloudLibraryService.bytesToMB(ReformCloudLibraryService.maxMemorySystem()))
             + "MB");
         commandSender.sendMessage(
-            "CPU (System/Internal): " + decimalFormat.format(ReformCloudLibraryService.cpuUsage())
+            "CPU (System/Internal): §e" + decimalFormat.format(ReformCloudLibraryService.cpuUsage())
                 + "/" + decimalFormat.format(ReformCloudLibraryService.internalCpuUsage()));
-        commandSender.sendMessage("Threads: " + Thread.getAllStackTraces().size());
+        commandSender.sendMessage("Threads: §e" + Thread.getAllStackTraces().size());
         commandSender.sendMessage(
-            "For further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
+            "§bFor further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
     }
 }

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/commands/CommandHelp.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/commands/CommandHelp.java
@@ -28,7 +28,7 @@ public final class CommandHelp extends Command implements Serializable {
     @Override
     public void executeCommand(CommandSender commandSender, String[] args) {
         commandSender.sendMessage("The following Commands are registered:");
-        ReformCloudClient.getInstance().getCommandManager().getCommands().forEach(
+        ReformCloudClient.getInstance().getCommandManager().commands().forEach(
             command -> commandSender.sendMessage(
                 "   - " + command.getName() + " | Aliases: §e" + Arrays.asList(command.getAliases())
                     + "§r | Description: §3" + command.getDescription() + "§r | Permission: " + (

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
@@ -7,7 +7,7 @@ package systems.reformcloud.configuration;
 import systems.reformcloud.ReformCloudClient;
 import systems.reformcloud.ReformCloudLibraryService;
 import systems.reformcloud.ReformCloudLibraryServiceProvider;
-import systems.reformcloud.logging.ColouredConsoleProvider;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.utility.ExitUtil;
 import systems.reformcloud.utility.Require;
 import systems.reformcloud.utility.StringUtil;
@@ -101,7 +101,8 @@ public final class CloudConfiguration implements Serializable {
             return;
         }
 
-        ColouredConsoleProvider colouredConsoleProvider = ReformCloudClient.getInstance().getColouredConsoleProvider();
+        AbstractLoggerProvider colouredConsoleProvider =
+            ReformCloudClient.getInstance().getColouredConsoleProvider();
 
         colouredConsoleProvider.info("Please provide the internal ReformCloudClient ip");
         String ip = this.readString(colouredConsoleProvider, s -> s.split("\\.").length == 4);
@@ -189,7 +190,7 @@ public final class CloudConfiguration implements Serializable {
             .readFileAsString(new File("reformcloud/files/ControllerKEY"));
     }
 
-    private String readString(final ColouredConsoleProvider colouredConsoleProvider, Predicate<String> checkable) {
+    private String readString(final AbstractLoggerProvider colouredConsoleProvider, Predicate<String> checkable) {
         String readLine = colouredConsoleProvider.readLine();
         while (readLine == null || !checkable.test(readLine) || readLine.trim().isEmpty()) {
             colouredConsoleProvider.info("Input invalid, please try again");

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
@@ -113,6 +113,10 @@ public final class CloudConfiguration implements Serializable {
             .info("Please provide the name of this Client. (Recommended: Client-01)");
         String clientID = this.readString(colouredConsoleProvider, s -> true);
 
+        ReformCloudClient.getInstance().getColouredConsoleProvider()
+            .info("Please provide the memory for this Client. (Min 512MB)");
+        Integer memory = this.readInt(colouredConsoleProvider, integer -> integer >= 512);
+
         Properties properties = new Properties();
 
         properties.setProperty("controller.ip", controllerIP);
@@ -121,7 +125,7 @@ public final class CloudConfiguration implements Serializable {
 
         properties.setProperty("general.client-name", clientID);
         properties.setProperty("general.start-host", ip);
-        properties.setProperty("general.memory", 1024 + StringUtil.EMPTY);
+        properties.setProperty("general.memory", memory + StringUtil.EMPTY);
         properties.setProperty("general.maxcpuusage", 90.00 + StringUtil.EMPTY);
         properties.setProperty("general.max-log-size", Integer.toString(46));
 
@@ -199,6 +203,21 @@ public final class CloudConfiguration implements Serializable {
 
         return readLine;
     }
+
+    private Integer readInt(final AbstractLoggerProvider colouredConsoleProvider,
+                            Predicate<Integer> checkable) {
+        String readLine = colouredConsoleProvider.readLine();
+        while (readLine == null
+            || readLine.trim().isEmpty()
+            || !ReformCloudLibraryService.checkIsInteger(readLine)
+            || !checkable.test(Integer.parseInt(readLine))) {
+            colouredConsoleProvider.info("Input invalid, please try again");
+            readLine = colouredConsoleProvider.readLine();
+        }
+
+        return Integer.parseInt(readLine);
+    }
+
 
     public String getControllerKey() {
         return this.controllerKey;

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/serverprocess/startup/CloudServerStartupHandler.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/serverprocess/startup/CloudServerStartupHandler.java
@@ -184,6 +184,8 @@ public final class CloudServerStartupHandler implements Serializable, ServiceAbl
 
         if (this.serverStartupInfo.getServerGroup().getSpigotVersions()
             .equals(SpigotVersions.SPONGEVANILLA_1_8_9)
+            || this.getServerStartupInfo().getServerGroup().getSpigotVersions()
+            .equals(SpigotVersions.SPONGEVANILLA_1_9_4)
             || this.serverStartupInfo.getServerGroup().getSpigotVersions()            
             .equals(SpigotVersions.SPONGEVANILLA_1_10_2)
             || this.serverStartupInfo.getServerGroup().getSpigotVersions()

--- a/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/serverprocess/startup/ProxyStartupHandler.java
+++ b/reformcloud-global/reformcloud-client/src/main/java/systems/reformcloud/serverprocess/startup/ProxyStartupHandler.java
@@ -196,7 +196,7 @@ public final class ProxyStartupHandler implements Serializable, ServiceAble {
             if (bufferedImage.getWidth() != 64 || bufferedImage.getHeight() != 64) {
                 ReformCloudClient.getInstance().getChannelHandler()
                     .sendPacketAsynchronous("ReformCloudController",
-                        new PacketOutIconSizeIncorrect(this.proxyStartupInfo.getName()));
+                        new PacketOutIconSizeIncorrect(this.proxyStartupInfo.getProxyGroup().getName()));
                 FileUtils.deleteFileIfExists(Paths.get(path + "/server-icon.png"));
                 FileUtils.copyCompiledFile("reformcloud/bungeecord/icon/server-icon.png",
                     path + "/server-icon.png");

--- a/reformcloud-global/reformcloud-controller/pom.xml
+++ b/reformcloud-global/reformcloud-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-global</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/reformcloud-global/reformcloud-controller/pom.xml
+++ b/reformcloud-global/reformcloud-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-global</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
@@ -893,7 +893,8 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -932,7 +933,8 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            SpigotVersions.SPIGOT_1_8_8
+            SpigotVersions.SPIGOT_1_8_8,
+            true
         );
         createServerGroup(serverGroup);
     }
@@ -956,7 +958,8 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
         createServerGroup(serverGroup);
     }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
@@ -348,8 +348,6 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
         new DefaultCloudService(this);
         DefaultPlayerProvider.instance.set(new PlayerProvider());
 
-        new PlayerLogoutHandler();
-
         colouredConsoleProvider.info(this.getLoadedLanguage().getLoading_done()
             .replace("%time%", String.valueOf(System.currentTimeMillis() - time)));
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
@@ -496,7 +496,6 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
      */
     @Override
     public void shutdownAll() {
-
         this.taskScheduler.close();
         this.statisticsProvider.save();
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
@@ -40,6 +40,7 @@ import systems.reformcloud.exceptions.InstanceAlreadyExistsException;
 import systems.reformcloud.exceptions.LoadException;
 import systems.reformcloud.language.LanguageManager;
 import systems.reformcloud.language.utility.Language;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.logging.ColouredConsoleProvider;
 import systems.reformcloud.meta.Template;
 import systems.reformcloud.meta.auto.start.AutoStart;
@@ -83,7 +84,7 @@ import systems.reformcloud.utility.defaults.DefaultCloudService;
 import systems.reformcloud.utility.runtime.Reload;
 import systems.reformcloud.utility.runtime.Shutdown;
 import systems.reformcloud.utility.screen.ScreenSessionProvider;
-import systems.reformcloud.utility.threading.TaskScheduler;
+import systems.reformcloud.utility.threading.AbstractTaskScheduler;
 import systems.reformcloud.utility.time.TimeSync;
 import systems.reformcloud.versioneering.VersionController;
 import systems.reformcloud.web.ReformWebServer;
@@ -106,9 +107,9 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
 
     private static ReformCloudController instance;
 
-    private CommandManager commandManager;
+    private AbstractCommandManager commandManager;
 
-    private ColouredConsoleProvider colouredConsoleProvider;
+    private AbstractLoggerProvider colouredConsoleProvider;
 
     private InternalCloudNetwork internalCloudNetwork = new InternalCloudNetwork();
 
@@ -128,7 +129,7 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
 
     private final IngameCommandManger ingameCommandManger = new IngameCommandMangerImpl();
 
-    private final TaskScheduler taskScheduler;
+    private final AbstractTaskScheduler taskScheduler;
 
     private List<UUID> uuid = new ArrayList<>();
 
@@ -1619,11 +1620,11 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
         return this.internalCloudNetwork.getLoaded();
     }
 
-    public CommandManager getCommandManager() {
+    public AbstractCommandManager getCommandManager() {
         return this.commandManager;
     }
 
-    public ColouredConsoleProvider getColouredConsoleProvider() {
+    public AbstractLoggerProvider getColouredConsoleProvider() {
         return this.colouredConsoleProvider;
     }
 
@@ -1663,7 +1664,7 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
         return this.ingameCommandManger;
     }
 
-    public TaskScheduler getTaskScheduler() {
+    public AbstractTaskScheduler getTaskScheduler() {
         return this.taskScheduler;
     }
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/ReformCloudController.java
@@ -5,39 +5,9 @@
 package systems.reformcloud;
 
 import com.google.gson.reflect.TypeToken;
-import java.io.File;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import systems.reformcloud.addons.AddonLoader;
 import systems.reformcloud.addons.AddonParallelLoader;
-import systems.reformcloud.api.APIService;
-import systems.reformcloud.api.DefaultPlayerProvider;
-import systems.reformcloud.api.RestAPIAuth;
-import systems.reformcloud.api.RestAPIClientList;
-import systems.reformcloud.api.RestAPIClients;
-import systems.reformcloud.api.RestAPIGetOfflinePlayer;
-import systems.reformcloud.api.RestAPIPermissionCheck;
-import systems.reformcloud.api.RestAPIProxyGroupList;
-import systems.reformcloud.api.RestAPIProxyList;
-import systems.reformcloud.api.RestAPIServerGroupList;
-import systems.reformcloud.api.RestAPIServerList;
-import systems.reformcloud.api.RestAPIStartGameserver;
-import systems.reformcloud.api.RestAPIStartProxy;
-import systems.reformcloud.api.RestAPIStopProxy;
-import systems.reformcloud.api.RestAPIStopServer;
+import systems.reformcloud.api.*;
 import systems.reformcloud.api.deployment.incoming.RestAPIDeploymentService;
 import systems.reformcloud.api.deployment.outgoing.RestAPIDownloadService;
 import systems.reformcloud.api.documentation.RestAPIDocumentation;
@@ -47,30 +17,7 @@ import systems.reformcloud.api.permissions.PermissionHelper;
 import systems.reformcloud.api.player.PlayerProvider;
 import systems.reformcloud.api.save.SaveAPIImpl;
 import systems.reformcloud.api.save.SaveAPIService;
-import systems.reformcloud.commands.CommandAddons;
-import systems.reformcloud.commands.CommandAssignment;
-import systems.reformcloud.commands.CommandClear;
-import systems.reformcloud.commands.CommandCopy;
-import systems.reformcloud.commands.CommandCreate;
-import systems.reformcloud.commands.CommandDelete;
-import systems.reformcloud.commands.CommandDeploy;
-import systems.reformcloud.commands.CommandDeveloper;
-import systems.reformcloud.commands.CommandExecute;
-import systems.reformcloud.commands.CommandExit;
-import systems.reformcloud.commands.CommandHelp;
-import systems.reformcloud.commands.CommandInfo;
-import systems.reformcloud.commands.CommandInstall;
-import systems.reformcloud.commands.CommandListGroups;
-import systems.reformcloud.commands.CommandLog;
-import systems.reformcloud.commands.CommandManager;
-import systems.reformcloud.commands.CommandProcess;
-import systems.reformcloud.commands.CommandReload;
-import systems.reformcloud.commands.CommandScreen;
-import systems.reformcloud.commands.CommandUpdate;
-import systems.reformcloud.commands.CommandUpload;
-import systems.reformcloud.commands.CommandVersion;
-import systems.reformcloud.commands.CommandWebPermissions;
-import systems.reformcloud.commands.CommandWhitelist;
+import systems.reformcloud.commands.*;
 import systems.reformcloud.commands.ingame.IngameCommandManger;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
@@ -115,62 +62,15 @@ import systems.reformcloud.network.NettyHandler;
 import systems.reformcloud.network.NettySocketServer;
 import systems.reformcloud.network.abstracts.AbstractChannelHandler;
 import systems.reformcloud.network.channel.ChannelHandler;
-import systems.reformcloud.network.in.PacketInAddProcess;
-import systems.reformcloud.network.in.PacketInAuthSuccess;
-import systems.reformcloud.network.in.PacketInClientProcessQueue;
-import systems.reformcloud.network.in.PacketInCommandExecute;
-import systems.reformcloud.network.in.PacketInConnectPlayer;
-import systems.reformcloud.network.in.PacketInCreateClient;
-import systems.reformcloud.network.in.PacketInCreateProxyGroup;
-import systems.reformcloud.network.in.PacketInCreateServerGroup;
-import systems.reformcloud.network.in.PacketInCreateWebUser;
-import systems.reformcloud.network.in.PacketInDispatchConsoleCommand;
-import systems.reformcloud.network.in.PacketInExecuteCommand;
-import systems.reformcloud.network.in.PacketInExecuteCommandSilent;
-import systems.reformcloud.network.in.PacketInGetControllerTemplate;
-import systems.reformcloud.network.in.PacketInGetLog;
-import systems.reformcloud.network.in.PacketInIconSizeIncorrect;
-import systems.reformcloud.network.in.PacketInKickPlayer;
-import systems.reformcloud.network.in.PacketInLoginPlayer;
-import systems.reformcloud.network.in.PacketInLogoutPlayer;
-import systems.reformcloud.network.in.PacketInProxyInfoUpdate;
-import systems.reformcloud.network.in.PacketInRemoveInternalProcess;
-import systems.reformcloud.network.in.PacketInRemoveProcess;
-import systems.reformcloud.network.in.PacketInSendControllerConsoleMessage;
-import systems.reformcloud.network.in.PacketInSendPlayerMessage;
-import systems.reformcloud.network.in.PacketInServerInfoUpdate;
-import systems.reformcloud.network.in.PacketInStartGameProcess;
-import systems.reformcloud.network.in.PacketInStartProxyProcess;
-import systems.reformcloud.network.in.PacketInStopProcess;
-import systems.reformcloud.network.in.PacketInUpdateControllerTemplate;
-import systems.reformcloud.network.in.PacketInUpdateInternalCloudNetwork;
-import systems.reformcloud.network.in.PacketInUpdateOfflinePlayer;
-import systems.reformcloud.network.in.PacketInUpdateOnlinePlayer;
-import systems.reformcloud.network.in.PacketInUpdateServerGroup;
-import systems.reformcloud.network.in.PacketInUpdateServerTempStats;
+import systems.reformcloud.network.in.*;
 import systems.reformcloud.network.interfaces.NetworkInboundHandler;
 import systems.reformcloud.network.interfaces.NetworkQueryInboundHandler;
-import systems.reformcloud.network.out.PacketOutExecuteCommand;
-import systems.reformcloud.network.out.PacketOutProxyInfoUpdate;
-import systems.reformcloud.network.out.PacketOutServerInfoUpdate;
-import systems.reformcloud.network.out.PacketOutStartGameServer;
-import systems.reformcloud.network.out.PacketOutStartProxy;
-import systems.reformcloud.network.out.PacketOutStopProcess;
-import systems.reformcloud.network.out.PacketOutUpdateAll;
+import systems.reformcloud.network.out.*;
 import systems.reformcloud.network.packet.Packet;
 import systems.reformcloud.network.packet.PacketFuture;
-import systems.reformcloud.network.query.in.PacketInQueryGetOnlinePlayer;
-import systems.reformcloud.network.query.in.PacketInQueryGetPlayer;
-import systems.reformcloud.network.query.in.PacketInQueryGetRuntimeInformation;
-import systems.reformcloud.network.query.in.PacketInQueryPlayerAccepted;
-import systems.reformcloud.network.query.in.PacketInQueryStartDevProcess;
+import systems.reformcloud.network.query.in.*;
 import systems.reformcloud.network.query.out.PacketOutQueryGetRuntimeInformation;
-import systems.reformcloud.network.sync.in.PacketInSyncClientDisconnects;
-import systems.reformcloud.network.sync.in.PacketInSyncClientReloadSuccess;
-import systems.reformcloud.network.sync.in.PacketInSyncExceptionThrown;
-import systems.reformcloud.network.sync.in.PacketInSyncNameToUUID;
-import systems.reformcloud.network.sync.in.PacketInSyncScreenUpdate;
-import systems.reformcloud.network.sync.in.PacketInSyncUpdateClientInfo;
+import systems.reformcloud.network.sync.in.*;
 import systems.reformcloud.network.sync.out.PacketOutSyncUpdateClient;
 import systems.reformcloud.player.implementations.OfflinePlayer;
 import systems.reformcloud.player.implementations.OnlinePlayer;
@@ -180,7 +80,6 @@ import systems.reformcloud.utility.Require;
 import systems.reformcloud.utility.StringUtil;
 import systems.reformcloud.utility.cloudsystem.InternalCloudNetwork;
 import systems.reformcloud.utility.defaults.DefaultCloudService;
-import systems.reformcloud.utility.player.PlayerLogoutHandler;
 import systems.reformcloud.utility.runtime.Reload;
 import systems.reformcloud.utility.runtime.Shutdown;
 import systems.reformcloud.utility.screen.ScreenSessionProvider;
@@ -188,6 +87,16 @@ import systems.reformcloud.utility.threading.TaskScheduler;
 import systems.reformcloud.utility.time.TimeSync;
 import systems.reformcloud.versioneering.VersionController;
 import systems.reformcloud.web.ReformWebServer;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * @author _Klaro | Pasqual K. / created on 18.10.2018
@@ -1117,6 +1026,36 @@ public final class ReformCloudController implements Serializable, Shutdown, Relo
     @Override
     public void updateServerGroup(ServerGroup serverGroup) {
         cloudConfiguration.updateServerGroup(serverGroup);
+    }
+
+    @Override
+    public void updateServerName(ServerInfo serverInfo, String newName) {
+        if (serverInfo == null || newName == null) {
+            return;
+        }
+
+        serverInfo.getCloudProcess().setName(newName);
+        this.updateServerInfo(serverInfo);
+    }
+
+    @Override
+    public void updateServerName(String serverName, String newName) {
+        this.updateServerName(this.getServerInfo(serverName), newName);
+    }
+
+    @Override
+    public void updateProxyName(ProxyInfo proxyInfo, String newName) {
+        if (proxyInfo == null || newName == null) {
+            return;
+        }
+
+        proxyInfo.getCloudProcess().setName(newName);
+        this.updateProxyInfo(proxyInfo);
+    }
+
+    @Override
+    public void updateProxyName(String proxyName, String newName) {
+        this.updateProxyName(this.getProxyInfo(proxyName), newName);
     }
 
     @Override

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAddons.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAddons.java
@@ -5,12 +5,13 @@
 package systems.reformcloud.commands;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+
 import systems.reformcloud.ReformCloudController;
+import systems.reformcloud.addons.JavaAddon;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
+import systems.reformcloud.utility.files.DownloadManager;
 
 /**
  * @author _Klaro | Pasqual K. / created on 03.02.2019
@@ -44,17 +45,277 @@ public final class CommandAddons extends Command implements Serializable {
                             .replace("%main%", e.getAddonClassConfig().getMain())
                     ));
             }
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("update")){
+            if (args[1].equalsIgnoreCase("signs")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudSigns"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudSigns");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudSigns.jar",
+                        "reformcloud/addons/ReformCloudSigns.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("discord")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudDiscord"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudDiscord");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudDiscord.jar",
+                        "reformcloud/addons/ReformCloudDiscordBot.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("permissions")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudPermissions"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudPermissions");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudPermissions.jar",
+                        "reformcloud/addons/ReformCloudPermissions.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("proxy")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudProxy"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudProxy");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudProxy.jar",
+                        "reformcloud/addons/ReformCloudProxy.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("parameters")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudParameters"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudParameters");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudParameters.jar",
+                        "reformcloud/addons/ReformCloudParameters.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("autoicon")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudAutoIcon"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudAutoIcon");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudAutoIcon.jar",
+                        "reformcloud/addons/ReformCloudAutoIcon.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("properties")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudProperties"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudProperties");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudProperties.jar",
+                        "reformcloud/addons/ReformCloudProperties.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("mobs")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudMob"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudMob");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudMobs.jar",
+                        "reformcloud/addons/ReformCloudMobs.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("cloudflare")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudCloudFlare"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudCloudFlare");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudCloudFlare.jar",
+                        "reformcloud/addons/ReformCloudCloudFlare.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("backup")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudBackup"))
+                    .findFirst().orElse(null) != null) {
+                    ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudBackup");
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudBackup.jar",
+                        "reformcloud/addons/ReformCloudBackup.jar");
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is not installed!"));
+                }
+            } else if (args[1].equalsIgnoreCase("--all")) {
+                if (ReformCloudController.getInstance().getAddonParallelLoader().getJavaAddons().size() == 0) {
+                    commandSender.sendMessage(ReformCloudController.getInstance().getLoadedLanguage()
+                        .getCommand_addons_no_addons_loaded());
+                } else {
+                    for (JavaAddon javaAddon : ReformCloudController.getInstance().getAddonParallelLoader().getJavaAddons()) {
+                        ReformCloudController.getInstance().getAddonParallelLoader().disableAddon(javaAddon.getAddonName());
+                        switch (javaAddon.getAddonName()) {
+
+                            case "ReformCloudDiscord": {
+                                DownloadManager.downloadSilentAndDisconnect(
+                                    "https://dl.reformcloud.systems/addons/ReformCloudDiscord.jar",
+                                    "reformcloud/addons/ReformCloudDiscordBot.jar");
+                                break;
+                            }
+
+                            case "ReformCloudMob": {
+                                DownloadManager.downloadSilentAndDisconnect(
+                                    "https://dl.reformcloud.systems/addons/ReformCloudMobs.jar",
+                                    "reformcloud/addons/ReformCloudMobs.jar");
+                                break;
+                            }
+
+                            default: {
+                                DownloadManager.downloadSilentAndDisconnect(
+                                    "https://dl.reformcloud.systems/addons/" + javaAddon.getAddonName() + ".jar",
+                                    "reformcloud/addons/" + javaAddon.getAddonName() + ".jar");
+                                break;
+                            }
+                        }
+                    }
+                    ReformCloudController.getInstance().reloadAllSave();
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                }
+            } else {
+                commandSender.sendMessage("addons list");
+                commandSender.sendMessage(
+                    "addons update <autoicon, backup, cloudflare, discord," + " mobs, parameters, permissions, proxy, properties, signs, --all>");
+            }
         } else {
             commandSender.sendMessage("addons list");
+            commandSender.sendMessage(
+                "addons update <autoicon, backup, cloudflare, discord," + " mobs, parameters, permissions, proxy, properties, signs, --all>");
         }
     }
 
     @Override
     public List<String> complete(String commandLine, String[] args) {
+        final List<String> out = new LinkedList<>();
         if (args.length == 0) {
-            return Collections.singletonList("list");
+            out.addAll(asList("list", "update"));
         }
 
-        return new ArrayList<>();
+        if (args.length == 1 && args[0].equalsIgnoreCase("update")) {
+            out.addAll(asList("AUTOICON", "BACKUP", "CLOUDFLARE", "DISCORD", "MOBS", "PARAMETERS", "PERMISSIONS",
+                "PROXY", "PROPERTIES", "SIGNS", "--ALL"));
+        }
+
+        return out;
     }
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAddons.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAddons.java
@@ -50,8 +50,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudSigns"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudSigns"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudSigns");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudSigns.jar",
@@ -71,8 +70,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudDiscord"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudDiscord"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudDiscord");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudDiscord.jar",
@@ -92,8 +90,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudPermissions"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudPermissions"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudPermissions");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudPermissions.jar",
@@ -113,8 +110,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudProxy"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudProxy"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudProxy");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudProxy.jar",
@@ -134,8 +130,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudParameters"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudParameters"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudParameters");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudParameters.jar",
@@ -155,8 +150,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudAutoIcon"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudAutoIcon"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudAutoIcon");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudAutoIcon.jar",
@@ -176,8 +170,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudProperties"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudProperties"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudProperties");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudProperties.jar",
@@ -197,8 +190,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudMob"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudMob"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudMob");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudMobs.jar",
@@ -218,8 +210,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudCloudFlare"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudCloudFlare"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudCloudFlare");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudCloudFlare.jar",
@@ -239,8 +230,7 @@ public final class CommandAddons extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudBackup"))
-                    .findFirst().orElse(null) != null) {
+                    .anyMatch(e -> e.getAddonName().equals("ReformCloudBackup"))) {
                     ReformCloudController.getInstance().getAddonParallelLoader().disableAddon("ReformCloudBackup");
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudBackup.jar",

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
@@ -374,7 +374,7 @@ public final class CommandAssignment extends Command implements Serializable {
             if (args[2].equalsIgnoreCase("version")) {
                 if (SpigotVersions.getByName(args[3]) == null) {
                     commandSender.sendMessage(language.getCommand_assignment_value_not_updatable()
-                        .replace("%reason%", "Please provide a valid serer version"));
+                        .replace("%reason%", "Please provide a valid server version"));
                     return;
                 }
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
@@ -912,7 +912,7 @@ public final class CommandAssignment extends Command implements Serializable {
     private void sendHelp(CommandSender commandSender) {
         commandSender.sendMessage(
             "assignment SERVERGROUP <name> <permission, clients, templates, memory, maxonline, " +
-                "minonline, maxplayers, startport, maintenance, savelogs, servermodetype, version> <value> <--update>");
+                "minonline, maxplayers, startport, maintenance, savelogs, servermodetype, version, onlyproxyjoin> <value> <--update>");
         commandSender.sendMessage(
             "assignment PROXYGROUP <name> <clients, templates, disabledgroups, maintenance, " +
                 "savelogs, memory, maxonline, minonline, proxymodetype, maxplayers, commandlogging, version> <value> <--update>");

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
@@ -90,6 +90,11 @@ public final class CommandAssignment extends Command implements Serializable {
                         .replace("%value%", args[3])
                         .replace("%group%", serverGroup.getName()));
                 } else {
+                    if (ReformCloudController.getInstance().getClient(args[3]) == null) {
+                        commandSender.sendMessage(language.getClient_not_found());
+                        return;
+                    }
+
                     if (serverGroup.getClients().contains(args[3])) {
                         commandSender
                             .sendMessage(language.getCommand_assignment_value_not_updatable()
@@ -419,6 +424,11 @@ public final class CommandAssignment extends Command implements Serializable {
                         .replace("%value%", args[3])
                         .replace("%group%", proxyGroup.getName()));
                 } else {
+                    if (ReformCloudController.getInstance().getClient(args[3]) == null) {
+                        commandSender.sendMessage(language.getClient_not_found());
+                        return;
+                    }
+
                     if (proxyGroup.getClients().contains(args[3])) {
                         commandSender
                             .sendMessage(language.getCommand_assignment_value_not_updatable()

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
@@ -392,6 +392,28 @@ public final class CommandAssignment extends Command implements Serializable {
                 return;
             }
 
+            if (args[2].equalsIgnoreCase("onlyproxyjoin")) {
+                if (!ReformCloudLibraryService.checkIsValidBoolean(args[3])) {
+                    commandSender.sendMessage(language.getCommand_assignment_value_not_updatable()
+                        .replace("%reason%", "Please provide a boolean as argument"));
+                    return;
+                }
+
+                boolean save = Boolean.parseBoolean(args[3]);
+                serverGroup.setOnlyProxyJoin(save);
+                ReformCloudController.getInstance().getCloudConfiguration()
+                    .updateServerGroup(serverGroup);
+                if (args.length == 5 && args[4].equalsIgnoreCase("--update")) {
+                    ReformCloudController.getInstance().reloadAllSave();
+                }
+
+                commandSender.sendMessage(language.getCommand_assignment_value_updated()
+                    .replace("%name%", args[2].toLowerCase())
+                    .replace("%group%", serverGroup.getName())
+                    .replace("%value%", args[3]));
+                return;
+            }
+
             this.sendHelp(commandSender);
         } else if ((args.length == 5 || args.length == 4) && args[0]
             .equalsIgnoreCase("proxygroup")) {
@@ -920,7 +942,7 @@ public final class CommandAssignment extends Command implements Serializable {
             if (args[0].equalsIgnoreCase("servergroup")) {
                 out.addAll(asList("permission", "clients", "templates",
                     "memory", "maxonline", "minonline", "maxplayers", "startport",
-                    "maintenance", "savelogs", "servermodetype", "version"));
+                    "maintenance", "savelogs", "servermodetype", "version", "onlyproxyjoin"));
             } else if (args[0].equalsIgnoreCase("proxygroup")) {
                 out.addAll(asList("clients", "templates", "disabledgroups",
                     "maintenance", "savelogs", "memory", "maxonline", "minonline",

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandAssignment.java
@@ -907,7 +907,7 @@ public final class CommandAssignment extends Command implements Serializable {
         }
 
         if (args.length == 2) {
-            if(args[0].equalsIgnoreCase("servergroup")) {
+            if (args[0].equalsIgnoreCase("servergroup")) {
                 out.addAll(asList("permission", "clients", "templates",
                     "memory", "maxonline", "minonline", "maxplayers", "startport",
                     "maintenance", "savelogs", "servermodetype", "version"));

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandClear.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandClear.java
@@ -26,7 +26,7 @@ public final class CommandClear extends Command implements Serializable {
     @Override
     public void executeCommand(CommandSender commandSender, String[] args) {
         try {
-            ReformCloudController.getInstance().getColouredConsoleProvider().getConsoleReader()
+            ReformCloudController.getInstance().getColouredConsoleProvider().consoleReader()
                 .clearScreen();
         } catch (final IOException ex) {
             StringUtil

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCopy.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCopy.java
@@ -4,6 +4,10 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.ReformCloudLibraryService;
 import systems.reformcloud.commands.utility.Command;
@@ -13,11 +17,6 @@ import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.network.out.PacketOutCopyServerIntoTemplate;
 import systems.reformcloud.network.out.PacketOutExecuteCommand;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 16.12.2018
@@ -124,7 +123,7 @@ public final class CommandCopy extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(servers());
         }
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCopy.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCopy.java
@@ -15,6 +15,9 @@ import systems.reformcloud.network.out.PacketOutCopyServerIntoTemplate;
 import systems.reformcloud.network.out.PacketOutExecuteCommand;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 16.12.2018
@@ -116,4 +119,26 @@ public final class CommandCopy extends Command implements Serializable {
             commandSender.sendMessage("copy <name> <file/directory>");
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(servers());
+        }
+
+        return out;
+    }
+
+    private List<String> servers() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredServers()
+            .forEach(servers -> out.add(servers.getCloudProcess().getName()));
+        ReformCloudController.getInstance().getAllRegisteredProxies()
+            .forEach(proxies -> out.add(proxies.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCreate.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCreate.java
@@ -4,6 +4,11 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
@@ -23,12 +28,6 @@ import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.meta.server.defaults.DefaultGroup;
 import systems.reformcloud.meta.server.versions.SpigotVersions;
 import systems.reformcloud.meta.web.WebUser;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.12.2018
@@ -242,10 +241,8 @@ public final class CommandCreate extends Command implements Serializable {
             out.addAll(asList("SERVERGROUP", "PROXYGROUP", "CLIENT", "WEBUSER", "TEMPLATE"));
         }
 
-        if (args.length == 1) {
-            if (args[0].equalsIgnoreCase("TEMPLATE")) {
-                out.addAll(groups());
-            }
+        if (args.length == 1 && args[0].equalsIgnoreCase("TEMPLATE")) {
+            out.addAll(groups());
         }
 
         return out;

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCreate.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCreate.java
@@ -4,18 +4,13 @@
 
 package systems.reformcloud.commands;
 
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
 import systems.reformcloud.configuration.CloudConfiguration;
 import systems.reformcloud.cryptic.StringEncrypt;
 import systems.reformcloud.language.utility.Language;
-import systems.reformcloud.logging.ColouredConsoleProvider;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.meta.Template;
 import systems.reformcloud.meta.client.Client;
 import systems.reformcloud.meta.enums.ProxyModeType;
@@ -28,6 +23,12 @@ import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.meta.server.defaults.DefaultGroup;
 import systems.reformcloud.meta.server.versions.SpigotVersions;
 import systems.reformcloud.meta.web.WebUser;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.12.2018
@@ -45,7 +46,8 @@ public final class CommandCreate extends Command implements Serializable {
     @Override
     public void executeCommand(CommandSender commandSender, String[] args) {
         if (args.length == 1 && args[0].equalsIgnoreCase("servergroup")) {
-            ColouredConsoleProvider colouredConsoleProvider = ReformCloudController.getInstance().getColouredConsoleProvider();
+            AbstractLoggerProvider colouredConsoleProvider =
+                ReformCloudController.getInstance().getColouredConsoleProvider();
             CloudConfiguration cloudConfiguration = ReformCloudController.getInstance()
                 .getCloudConfiguration();
 
@@ -80,7 +82,8 @@ public final class CommandCreate extends Command implements Serializable {
                     ServerModeType.of(resetType)));
             return;
         } else if (args.length == 1 && args[0].equalsIgnoreCase("proxygroup")) {
-            ColouredConsoleProvider colouredConsoleProvider = ReformCloudController.getInstance().getColouredConsoleProvider();
+            AbstractLoggerProvider colouredConsoleProvider =
+                ReformCloudController.getInstance().getColouredConsoleProvider();
             CloudConfiguration cloudConfiguration = ReformCloudController.getInstance()
                 .getCloudConfiguration();
 
@@ -109,7 +112,7 @@ public final class CommandCreate extends Command implements Serializable {
                     ProxyModeType.of(resetType)));
             return;
         } else if (args.length == 1 && args[0].equalsIgnoreCase("client")) {
-            ColouredConsoleProvider colouredConsoleProvider = ReformCloudController.getInstance().getColouredConsoleProvider();
+            AbstractLoggerProvider colouredConsoleProvider = ReformCloudController.getInstance().getColouredConsoleProvider();
             CloudConfiguration cloudConfiguration = ReformCloudController.getInstance()
                 .getCloudConfiguration();
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCreate.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandCreate.java
@@ -25,7 +25,10 @@ import systems.reformcloud.meta.server.versions.SpigotVersions;
 import systems.reformcloud.meta.web.WebUser;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.12.2018
@@ -230,4 +233,33 @@ public final class CommandCreate extends Command implements Serializable {
                 commandSender.sendMessage("create TEMPLATE <group> <name>");
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if (args.length == 0) {
+            out.addAll(asList("SERVERGROUP", "PROXYGROUP", "CLIENT", "WEBUSER", "TEMPLATE"));
+        }
+
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("TEMPLATE")) {
+                out.addAll(groups());
+            }
+        }
+
+        return out;
+    }
+
+    private List<String> groups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllServerGroups()
+            .forEach(group -> out.add(group.getName()));
+        ReformCloudController.getInstance().getAllProxyGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDelete.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDelete.java
@@ -4,6 +4,11 @@
 
 package systems.reformcloud.commands;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.ReformCloudLibraryServiceProvider;
 import systems.reformcloud.commands.utility.Command;
@@ -14,12 +19,6 @@ import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.meta.web.WebUser;
 import systems.reformcloud.network.out.PacketOutDeleteTemplate;
 import systems.reformcloud.utility.StringUtil;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 16.12.2018
@@ -209,7 +208,7 @@ public final class CommandDelete extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("SERVERGROUP", "PROXYGROUP", "CLIENT", "WEBUSER"));
         }
 
@@ -246,7 +245,7 @@ public final class CommandDelete extends Command implements Serializable {
 
     private List<String> clients() {
         List<String> out = new LinkedList<>();
-        ReformCloudController.getInstance().getAllConnectedClients()
+        ReformCloudController.getInstance().getAllClients()
             .forEach(client -> out.add(client.getName()));
         Collections.sort(out);
         return out;

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDelete.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDelete.java
@@ -17,6 +17,9 @@ import systems.reformcloud.utility.StringUtil;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 16.12.2018
@@ -201,4 +204,61 @@ public final class CommandDelete extends Command implements Serializable {
             }
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("SERVERGROUP", "PROXYGROUP", "CLIENT", "WEBUSER"));
+        }
+
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("servergroup")) {
+                out.addAll(serverGroups());
+            } else if (args[0].equalsIgnoreCase("proxygroup")) {
+                out.addAll(proxyGroups());
+            } else if (args[0].equalsIgnoreCase("client")) {
+                out.addAll(clients());
+            } else if (args[0].equalsIgnoreCase("webuser")) {
+                out.addAll(users());
+            }
+        }
+
+        return out;
+    }
+
+    private List<String> serverGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllServerGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxyGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllProxyGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> users() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getCloudConfiguration()
+            .getWebUsers()
+            .forEach(user -> out.add(user.getUserName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeploy.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeploy.java
@@ -4,6 +4,10 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
@@ -11,11 +15,6 @@ import systems.reformcloud.meta.enums.TemplateBackend;
 import systems.reformcloud.meta.proxy.ProxyGroup;
 import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.network.out.PacketOutDeployServer;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 10.04.2019
@@ -155,11 +154,11 @@ public final class CommandDeploy extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("PROXY", "SERVER"));
         }
 
-        if(args.length == 1) {
+        if (args.length == 1) {
             if (args[0].equalsIgnoreCase("SERVER")) {
                 out.addAll(serverGroups());
             } else if (args[0].equalsIgnoreCase("PROXY")) {
@@ -167,7 +166,7 @@ public final class CommandDeploy extends Command implements Serializable {
             }
         }
 
-        if(args.length == 2) {
+        if (args.length == 2) {
             if (args[0].equalsIgnoreCase("SERVER")) {
                 out.addAll(serverTemplates(args[1]));
             } else if (args[0].equalsIgnoreCase("PROXY")) {
@@ -175,11 +174,11 @@ public final class CommandDeploy extends Command implements Serializable {
             }
         }
 
-        if(args.length == 3) {
+        if (args.length == 3) {
             out.addAll(clients());
         }
 
-        if(args.length == 4) {
+        if (args.length == 4) {
             out.addAll(clientSort(args[3]));
         }
 
@@ -229,8 +228,7 @@ public final class CommandDeploy extends Command implements Serializable {
     }
 
     private List<String> clientSort(String name) {
-        List<String> out = new LinkedList<>();
-        out.addAll(clients());
+        List<String> out = new LinkedList<>(clients());
         out.remove(name);
         Collections.sort(out);
         return out;

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeploy.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeploy.java
@@ -13,6 +13,9 @@ import systems.reformcloud.meta.server.ServerGroup;
 import systems.reformcloud.network.out.PacketOutDeployServer;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 10.04.2019
@@ -145,6 +148,91 @@ public final class CommandDeploy extends Command implements Serializable {
             }
         }
 
-        commandSender.sendMessage("deploy <proxy/server> <name> <template> <client1> <client2>");
+        commandSender.sendMessage("deploy <proxy/server> <group-name> <template> <client1> <client2>");
+    }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("PROXY", "SERVER"));
+        }
+
+        if(args.length == 1) {
+            if (args[0].equalsIgnoreCase("SERVER")) {
+                out.addAll(serverGroups());
+            } else if (args[0].equalsIgnoreCase("PROXY")) {
+                out.addAll(proxyGroups());
+            }
+        }
+
+        if(args.length == 2) {
+            if (args[0].equalsIgnoreCase("SERVER")) {
+                out.addAll(serverTemplates(args[1]));
+            } else if (args[0].equalsIgnoreCase("PROXY")) {
+                out.addAll(proxyTemplates(args[1]));
+            }
+        }
+
+        if(args.length == 3) {
+            out.addAll(clients());
+        }
+
+        if(args.length == 4) {
+            out.addAll(clientSort(args[3]));
+        }
+
+        return out;
+    }
+
+    private List<String> serverGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllServerGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxyGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllProxyGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> serverTemplates(String name) {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getServerGroup(name)
+            .getTemplates()
+            .forEach(template -> out.add(template.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxyTemplates(String name) {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getProxyGroup(name)
+            .getTemplates()
+            .forEach(template -> out.add(template.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clientSort(String name) {
+        List<String> out = new LinkedList<>();
+        out.addAll(clients());
+        out.remove(name);
+        Collections.sort(out);
+        return out;
     }
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeveloper.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeveloper.java
@@ -4,6 +4,10 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
@@ -13,11 +17,6 @@ import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.network.out.PacketOutEnableDebug;
 import systems.reformcloud.network.sync.out.PacketOutSyncStandby;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 15.04.2019
@@ -220,7 +219,7 @@ public final class CommandDeveloper extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("DEBUG", "STANDBY"));
         }
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeveloper.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandDeveloper.java
@@ -15,6 +15,9 @@ import systems.reformcloud.network.out.PacketOutEnableDebug;
 import systems.reformcloud.network.sync.out.PacketOutSyncStandby;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 15.04.2019
@@ -212,4 +215,62 @@ public final class CommandDeveloper extends Command implements Serializable {
         commandSender.sendMessage("dev debug <enable, disable> <controller, --all>");
         commandSender.sendMessage("dev standby <enable, disable> client");
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("DEBUG", "STANDBY"));
+        }
+
+        if (args.length == 1) {
+            out.addAll(asList("ENABLE", "DISABLE"));
+        }
+
+        if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("STANDBY")) {
+                out.addAll(clients());
+            } else if (args[0].equalsIgnoreCase("DEBUG")) {
+                out.addAll(asList("SERVER", "PROXY", "CLIENT", "CONTROLLER", "--all"));
+            }
+        }
+
+        if (args.length == 3) {
+            if (args[2].equalsIgnoreCase("SERVER")) {
+                out.addAll(servers());
+            } else if (args[2].equalsIgnoreCase("PROXY")) {
+                out.addAll(proxies());
+            } else if (args[2].equalsIgnoreCase("CLIENT")) {
+                out.addAll(clients());
+            }
+        }
+
+        return out;
+    }
+
+    private List<String> servers() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredServers()
+            .forEach(servers -> out.add(servers.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxies() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredProxies()
+            .forEach(proxies -> out.add(proxies.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandExecute.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandExecute.java
@@ -11,6 +11,9 @@ import systems.reformcloud.network.out.PacketOutExecuteCommand;
 import systems.reformcloud.utility.StringUtil;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 08.12.2018
@@ -120,4 +123,31 @@ public final class CommandExecute extends Command implements Serializable {
             }
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("SERVER", "PROXY"));
+        }
+
+        if(args.length == 1) {
+            out.addAll(servers());
+        }
+
+        return out;
+    }
+
+    private List<String> servers() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredServers()
+            .forEach(servers -> out.add(servers.getCloudProcess().getName()));
+        ReformCloudController.getInstance().getAllRegisteredProxies()
+            .forEach(proxies -> out.add(proxies.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandExecute.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandExecute.java
@@ -4,16 +4,15 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
 import systems.reformcloud.network.out.PacketOutExecuteCommand;
 import systems.reformcloud.utility.StringUtil;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 08.12.2018
@@ -128,11 +127,11 @@ public final class CommandExecute extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("SERVER", "PROXY"));
         }
 
-        if(args.length == 1) {
+        if (args.length == 1) {
             out.addAll(servers());
         }
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandHelp.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandHelp.java
@@ -28,7 +28,7 @@ public final class CommandHelp extends Command implements Serializable {
     @Override
     public void executeCommand(CommandSender commandSender, String[] args) {
         commandSender.sendMessage("The following Commands are registered:");
-        ReformCloudController.getInstance().getCommandManager().getCommands().forEach(
+        ReformCloudController.getInstance().getCommandManager().commands().forEach(
             command -> commandSender.sendMessage(
                 "   - " + command.getName() + " | Aliases: §e" + Arrays.asList(command.getAliases())
                     + "§r | Description: §3" + command.getDescription() + "§r | Permission: §e" + (

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandHelp.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandHelp.java
@@ -36,16 +36,16 @@ public final class CommandHelp extends Command implements Serializable {
 
         ReformCloudController.getInstance().getColouredConsoleProvider().emptyLine();
 
-        commandSender.sendMessage("Ram: " + decimalFormat.format(
+        commandSender.sendMessage("Ram: §e" + decimalFormat.format(
             ReformCloudLibraryService.bytesToMB(ReformCloudLibraryService.usedMemorySystem()))
             + "MB/" + decimalFormat.format(
             ReformCloudLibraryService.bytesToMB(ReformCloudLibraryService.maxMemorySystem()))
             + "MB");
         commandSender.sendMessage(
-            "CPU (System/Internal): " + decimalFormat.format(ReformCloudLibraryService.cpuUsage())
+            "CPU (System/Internal): §e" + decimalFormat.format(ReformCloudLibraryService.cpuUsage())
                 + "/" + decimalFormat.format(ReformCloudLibraryService.internalCpuUsage()));
-        commandSender.sendMessage("Threads: " + Thread.getAllStackTraces().size());
+        commandSender.sendMessage("Threads: §e" + Thread.getAllStackTraces().size());
         commandSender.sendMessage(
-            "For further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
+            "§bFor further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
     }
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInfo.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInfo.java
@@ -13,6 +13,8 @@ import systems.reformcloud.utility.StringUtil;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 16.12.2018
@@ -29,8 +31,15 @@ public final class CommandInfo extends Command implements Serializable {
 
     @Override
     public void executeCommand(CommandSender commandSender, String[] args) {
-        final Stats stats = ReformCloudController.getInstance()
+            final Stats stats = ReformCloudController.getInstance()
             .getStatisticsProvider().getStats();
+
+        final List<Integer> openedPorts = new LinkedList<>();
+
+        ReformCloudController.getInstance().getAllRegisteredServers().
+            forEach(e -> openedPorts.add(e.getPort()));
+        ReformCloudController.getInstance().getAllRegisteredProxies().
+            forEach(e -> openedPorts.add(e.getPort()));
 
         commandSender.sendMessage("ReformCloud version §e" + StringUtil.REFORM_VERSION);
         commandSender.sendMessage("Main developer: §e_Klaro");
@@ -53,6 +62,10 @@ public final class CommandInfo extends Command implements Serializable {
                 : this.dataFormat.format(stats.getServerOnlineTime())));
         commandSender.sendMessage("GameServer walked distance: §e" + stats.getWalkedDistance());
         commandSender.sendMessage("GameServer placed blocks: §e" + stats.getBlocksPlaced());
+        commandSender.sendMessage("Opened Ports: §e" + (openedPorts.size() > 0 ? openedPorts
+            .toString()
+            .replace("[", "")
+            .replace("]", "") : "no opened ports"));
         commandSender.sendMessage(
             "§bFor further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
     }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInfo.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInfo.java
@@ -32,28 +32,28 @@ public final class CommandInfo extends Command implements Serializable {
         final Stats stats = ReformCloudController.getInstance()
             .getStatisticsProvider().getStats();
 
-        commandSender.sendMessage("ReformCloud version " + StringUtil.REFORM_VERSION);
-        commandSender.sendMessage("Main developer: _Klaro");
-        commandSender.sendMessage("All startup: " + stats.getStartup());
-        commandSender.sendMessage("Root startup: " + stats.getRootStartup());
-        commandSender.sendMessage("First startup: " + stats.getFirstStartup());
-        commandSender.sendMessage("Last startup: " + stats.getLastStartup());
+        commandSender.sendMessage("ReformCloud version §e" + StringUtil.REFORM_VERSION);
+        commandSender.sendMessage("Main developer: §e_Klaro");
+        commandSender.sendMessage("All startup: §e" + stats.getStartup());
+        commandSender.sendMessage("Root startup: §e" + stats.getRootStartup());
+        commandSender.sendMessage("First startup: §e" + stats.getFirstStartup());
+        commandSender.sendMessage("Last startup: §e" + stats.getLastStartup());
         commandSender.sendMessage(
-            "Last shutdown: " + (stats.hasShutdown() ? stats.getLastShutdown() : "never"));
-        commandSender.sendMessage("Player login: " + stats.getLogin());
-        commandSender.sendMessage("Executed console command: " + stats.getConsoleCommands());
-        commandSender.sendMessage("Executed ingame command: " + stats.getIngameCommands());
-        commandSender.sendMessage("JVM start time: " +
+            "Last shutdown: §e" + (stats.hasShutdown() ? stats.getLastShutdown() : "never"));
+        commandSender.sendMessage("Player login: §e" + stats.getLogin());
+        commandSender.sendMessage("Executed console command: §e" + stats.getConsoleCommands());
+        commandSender.sendMessage("Executed ingame command: §e" + stats.getIngameCommands());
+        commandSender.sendMessage("JVM start time: §e" +
             ReformCloudController.getInstance().getColouredConsoleProvider().getDateFormat()
                 .format(ReformCloudLibraryService.systemStartTime()));
-        commandSender.sendMessage("JVM uptime: " +
+        commandSender.sendMessage("JVM uptime: §e" +
             dataFormat.format(ReformCloudLibraryService.systemUpTime()));
-        commandSender.sendMessage("GameServer online time: " +
+        commandSender.sendMessage("GameServer online time: §e" +
             (stats.getServerOnlineTime() == 0 ? "00:00:00.000"
                 : this.dataFormat.format(stats.getServerOnlineTime())));
-        commandSender.sendMessage("GameServer walked distance: " + stats.getWalkedDistance());
-        commandSender.sendMessage("GameServer placed blocks: " + stats.getBlocksPlaced());
+        commandSender.sendMessage("GameServer walked distance: §e" + stats.getWalkedDistance());
+        commandSender.sendMessage("GameServer placed blocks: §e" + stats.getBlocksPlaced());
         commandSender.sendMessage(
-            "For further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
+            "§bFor further information please contact us on our Discord (\"https://discord.gg/uskXdVZ\")");
     }
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
@@ -4,14 +4,13 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
 import systems.reformcloud.utility.files.DownloadManager;
-
-import java.io.Serializable;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 06.04.2019
@@ -125,7 +124,7 @@ public final class CommandInstall extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("AUTOICON", "BACKUP", "CLOUDFLARE", "DISCORD", "MOBS", "PARAMETERS", "PERMISSIONS",
                 "PROXY", "PROPERTIES", "SIGNS"));
         }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
@@ -26,92 +26,214 @@ public final class CommandInstall extends Command implements Serializable {
     public void executeCommand(CommandSender commandSender, String[] args) {
         if (args.length == 1) {
             if (args[0].equalsIgnoreCase("signs")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudSigns.jar",
-                    "reformcloud/addons/ReformCloudSigns.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudSigns"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudSigns.jar",
+                        "reformcloud/addons/ReformCloudSigns.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("discord")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudDiscord.jar",
-                    "reformcloud/addons/ReformCloudDiscordBot.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudDiscord"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudDiscord.jar",
+                        "reformcloud/addons/ReformCloudDiscordBot.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("permissions")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudPermissions.jar",
-                    "reformcloud/addons/ReformCloudPermissions.jar");
-                commandSender.sendMessage("Download was completed successfully");
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudPermissions"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudPermissions.jar",
+                        "reformcloud/addons/ReformCloudPermissions.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("proxy")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudProxy.jar",
-                    "reformcloud/addons/ReformCloudProxy.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudProxy"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudProxy.jar",
+                        "reformcloud/addons/ReformCloudProxy.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("parameters")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudParameters.jar",
-                    "reformcloud/addons/ReformCloudParameters.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudParamaeters"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudParameters.jar",
+                        "reformcloud/addons/ReformCloudParameters.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("autoicon")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudAutoIcon.jar",
-                    "reformcloud/addons/ReformCloudAutoIcon.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudAutoIcon"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudAutoIcon.jar",
+                        "reformcloud/addons/ReformCloudAutoIcon.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("properties")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudProperties.jar",
-                    "reformcloud/addons/ReformCloudProperties.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudProperties"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudProperties.jar",
+                        "reformcloud/addons/ReformCloudProperties.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("mobs")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudMobs.jar",
-                    "reformcloud/addons/ReformCloudMobs.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudMob"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudMobs.jar",
+                        "reformcloud/addons/ReformCloudMobs.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("cloudflare")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudCloudFlare.jar",
-                    "reformcloud/addons/ReformCloudCloudFlare.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudCloudFlare"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudCloudFlare.jar",
+                        "reformcloud/addons/ReformCloudCloudFlare.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             } else if (args[0].equalsIgnoreCase("backup")) {
-                DownloadManager.downloadSilentAndDisconnect(
-                    "https://dl.reformcloud.systems/addons/ReformCloudBackup.jar",
-                    "reformcloud/addons/ReformCloudBackup.jar");
-                commandSender.sendMessage(
-                    ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
-                );
-                ReformCloudController.getInstance().reloadAllSave();
+                if (ReformCloudController.getInstance().getAddonParallelLoader()
+                    .getJavaAddons()
+                    .stream()
+                    .filter(e -> e.getAddonName().equals("ReformCloudBackup"))
+                    .findFirst().orElse(null) == null) {
+                    DownloadManager.downloadSilentAndDisconnect(
+                        "https://dl.reformcloud.systems/addons/ReformCloudBackup.jar",
+                        "reformcloud/addons/ReformCloudBackup.jar");
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage().getDownload_success()
+                    );
+                    ReformCloudController.getInstance().reloadAllSave();
+                } else {
+                    commandSender.sendMessage(
+                        ReformCloudController.getInstance().getLoadedLanguage()
+                            .getCommand_error_occurred()
+                            .replace("%message%",
+                                "This addon is already installed!"));
+                }
                 return;
             }
         }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
@@ -29,8 +29,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudSigns"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudSigns"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudSigns.jar",
                         "reformcloud/addons/ReformCloudSigns.jar");
@@ -50,8 +49,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudDiscord"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudDiscord"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudDiscord.jar",
                         "reformcloud/addons/ReformCloudDiscordBot.jar");
@@ -71,8 +69,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudPermissions"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudPermissions"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudPermissions.jar",
                         "reformcloud/addons/ReformCloudPermissions.jar");
@@ -92,8 +89,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudProxy"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudProxy"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudProxy.jar",
                         "reformcloud/addons/ReformCloudProxy.jar");
@@ -113,8 +109,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudParamaeters"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudParamaeters"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudParameters.jar",
                         "reformcloud/addons/ReformCloudParameters.jar");
@@ -134,8 +129,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudAutoIcon"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudAutoIcon"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudAutoIcon.jar",
                         "reformcloud/addons/ReformCloudAutoIcon.jar");
@@ -155,8 +149,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudProperties"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudProperties"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudProperties.jar",
                         "reformcloud/addons/ReformCloudProperties.jar");
@@ -176,8 +169,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudMob"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudMob"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudMobs.jar",
                         "reformcloud/addons/ReformCloudMobs.jar");
@@ -197,8 +189,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudCloudFlare"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudCloudFlare"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudCloudFlare.jar",
                         "reformcloud/addons/ReformCloudCloudFlare.jar");
@@ -218,8 +209,7 @@ public final class CommandInstall extends Command implements Serializable {
                 if (ReformCloudController.getInstance().getAddonParallelLoader()
                     .getJavaAddons()
                     .stream()
-                    .filter(e -> e.getAddonName().equals("ReformCloudBackup"))
-                    .findFirst().orElse(null) == null) {
+                    .noneMatch(e -> e.getAddonName().equals("ReformCloudBackup"))) {
                     DownloadManager.downloadSilentAndDisconnect(
                         "https://dl.reformcloud.systems/addons/ReformCloudBackup.jar",
                         "reformcloud/addons/ReformCloudBackup.jar");

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandInstall.java
@@ -10,6 +10,8 @@ import systems.reformcloud.commands.utility.CommandSender;
 import systems.reformcloud.utility.files.DownloadManager;
 
 import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 06.04.2019
@@ -116,6 +118,19 @@ public final class CommandInstall extends Command implements Serializable {
         }
 
         commandSender.sendMessage(
-            "install <signs, discord, permissions, proxy, parameters, autoicon, properties, mobs, cloudflare, backup>");
+            "install <autoicon, backup, cloudflare, discord, mobs, parameters, permissions, proxy, properties, signs>");
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("AUTOICON", "BACKUP", "CLOUDFLARE", "DISCORD", "MOBS", "PARAMETERS", "PERMISSIONS",
+                "PROXY", "PROPERTIES", "SIGNS"));
+        }
+
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandLog.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandLog.java
@@ -19,6 +19,9 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 29.01.2019
@@ -124,4 +127,50 @@ public final class CommandLog extends Command implements Serializable {
             }
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if (args.length == 0) {
+            out.addAll(asList("SERVER", "PROXY", "CLIENT", "CONTROLLER"));
+        }
+
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("server")) {
+                out.addAll(servers());
+            } else if (args[0].equalsIgnoreCase("proxy")) {
+                out.addAll(proxies());
+            } else if (args[0].equalsIgnoreCase("client")) {
+                out.addAll(clients());
+            }
+        }
+
+        return out;
+    }
+
+    private List<String> servers() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredServers()
+            .forEach(servers -> out.add(servers.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxies() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredProxies()
+            .forEach(proxies -> out.add(proxies.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
@@ -154,6 +154,7 @@ public final class CommandProcess extends Command implements Serializable {
                         commandSender.sendMessage(language.getCommand_process_trying_startup());
                     } else {
                         commandSender.sendMessage(language.getNo_available_client_for_startup());
+                        break;
                     }
                     ReformCloudLibraryService.sleep(200);
                 }
@@ -183,6 +184,7 @@ public final class CommandProcess extends Command implements Serializable {
                         commandSender.sendMessage(language.getCommand_process_trying_startup());
                     } else {
                         commandSender.sendMessage(language.getNo_available_client_for_startup());
+                        break;
                     }
                     ReformCloudLibraryService.sleep(200);
                 }
@@ -403,7 +405,7 @@ public final class CommandProcess extends Command implements Serializable {
                                     .getServerProcessManager().getAllRegisteredServerProcesses().stream()
                                     .filter(serverInfo -> serverInfo.getCloudProcess().getClient()
                                         .equals(e.getName())).forEach(info -> commandSender.sendMessage(
-                                    "    - §e" + info.getCloudProcess().getName() + "§r | State: §e" + info
+                                    "    - §e" + info.getCloudProcess().getName() + "§r | Maintenance: §e" + info.getServerGroup().isMaintenance() +  "§r | State: §e" + info
                                         .getServerState() + "§r | Player: §e" + info.getOnline() + "§r/§e" + info
                                         .getServerGroup().getMaxPlayers()));
                                 ReformCloudController.getInstance().getColouredConsoleProvider().emptyLine();

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
@@ -405,7 +405,7 @@ public final class CommandProcess extends Command implements Serializable {
                                     .getServerProcessManager().getAllRegisteredServerProcesses().stream()
                                     .filter(serverInfo -> serverInfo.getCloudProcess().getClient()
                                         .equals(e.getName())).forEach(info -> commandSender.sendMessage(
-                                    "    - §e" + info.getCloudProcess().getName() + "§r | Maintenance: §e" + info.getServerGroup().isMaintenance() +  "§r | State: §e" + info
+                                    "    - §e" + info.getCloudProcess().getName() + "§r | State: §e" + info
                                         .getServerState() + "§r | Player: §e" + info.getOnline() + "§r/§e" + info
                                         .getServerGroup().getMaxPlayers()));
                                 ReformCloudController.getInstance().getColouredConsoleProvider().emptyLine();

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
@@ -460,7 +460,7 @@ public final class CommandProcess extends Command implements Serializable {
                                         "The following §eproxies§r of the group \"§e" + args[2]
                                             + "§r\" are connected: ");
                                     connected.forEach(info -> commandSender.sendMessage(
-                                        "    - §e" + info.getCloudProcess().getName() + "§r | Player: §e" + info
+                                        "    - §e" + info.getCloudProcess().getName() + "§r | Maintenance: §e" + info.getProxyGroup().isMaintenance() + "§r | Player: §e" + info
                                             .getOnline() + "§r/§e" + info.getProxyGroup().getMaxPlayers()));
                                 } else
                                     commandSender.sendMessage("There are no started §eproxies§r of the group \"§e" + args[2] + "§r\"");

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
@@ -20,9 +20,7 @@ import systems.reformcloud.network.out.*;
 
 import java.io.Serializable;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -634,4 +632,112 @@ public final class CommandProcess extends Command implements Serializable {
             }
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("STOP", "RESTART", "STOPGROUP", "START",
+                "LIST", "QUEUE"));
+        }
+
+        if(args.length == 1) {
+            if (args[0].equalsIgnoreCase("START")) {
+                out.addAll(serverGroups());
+                out.addAll(proxyGroups());
+            } else if (args[0].equalsIgnoreCase("STOP")) {
+                out.addAll(servers());
+                out.addAll(proxies());
+                out.addAll(asList("--all", "--empty"));
+            } else if (args[0].equalsIgnoreCase("STOPGROUP")) {
+                out.addAll(serverGroups());
+                out.addAll(proxyGroups());
+            } else if (args[0].equalsIgnoreCase("RESTART")) {
+                out.addAll(servers());
+                out.addAll(proxies());
+            }  else if (args[0].equalsIgnoreCase("LIST")) {
+                out.addAll(asList("SERVER", "PROXY"));
+            } else if (args[0].equalsIgnoreCase("QUEUE")) {
+                out.addAll(clients());
+            }
+        }
+
+        if(args.length == 2) {
+            if (args[0].equalsIgnoreCase("QUEUE")) {
+                out.addAll(asList("list", "remove"));
+            } else if (args[0].equalsIgnoreCase("LIST")) {
+                if (args[1].equalsIgnoreCase("SERVER")) {
+                    out.addAll(serverGroups());
+                } else if (args[1].equalsIgnoreCase("PROXY")) {
+                    out.addAll(proxyGroups());
+                }
+            }
+        }
+
+        if(args.length == 3) {
+            if (args[3].equalsIgnoreCase("remove")) {
+                out.addAll(asList("SERVER", "PROXY"));
+            }
+        }
+
+        if(args.length == 4) {
+            if (args[3].equalsIgnoreCase("SERVER")) {
+                out.addAll(servers());
+            } else if (args[3].equalsIgnoreCase("PROXY")) {
+                out.addAll(proxies());
+            }
+        }
+
+        return out;
+    }
+
+    private List<String> serverGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllServerGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxyGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllProxyGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> servers() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredServers()
+            .forEach(servers -> out.add(servers.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxies() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredProxies()
+            .forEach(proxies -> out.add(proxies.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clientSort(String name) {
+        List<String> out = new LinkedList<>();
+        out.addAll(clients());
+        out.remove(name);
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandProcess.java
@@ -4,6 +4,14 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.ReformCloudLibraryService;
 import systems.reformcloud.commands.utility.Command;
@@ -16,12 +24,12 @@ import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.meta.proxy.ProxyGroup;
 import systems.reformcloud.meta.server.ServerGroup;
-import systems.reformcloud.network.out.*;
-
-import java.io.Serializable;
-import java.text.DecimalFormat;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
+import systems.reformcloud.network.out.PacketOutGetClientProcessQueue;
+import systems.reformcloud.network.out.PacketOutRemoveProxyQueueProcess;
+import systems.reformcloud.network.out.PacketOutRemoveServerQueueProcess;
+import systems.reformcloud.network.out.PacketOutStartGameServer;
+import systems.reformcloud.network.out.PacketOutStartProxy;
+import systems.reformcloud.network.out.PacketOutStopProcess;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.12.2018
@@ -637,12 +645,12 @@ public final class CommandProcess extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("STOP", "RESTART", "STOPGROUP", "START",
                 "LIST", "QUEUE"));
         }
 
-        if(args.length == 1) {
+        if (args.length == 1) {
             if (args[0].equalsIgnoreCase("START")) {
                 out.addAll(serverGroups());
                 out.addAll(proxyGroups());
@@ -656,14 +664,14 @@ public final class CommandProcess extends Command implements Serializable {
             } else if (args[0].equalsIgnoreCase("RESTART")) {
                 out.addAll(servers());
                 out.addAll(proxies());
-            }  else if (args[0].equalsIgnoreCase("LIST")) {
+            } else if (args[0].equalsIgnoreCase("LIST")) {
                 out.addAll(asList("SERVER", "PROXY"));
             } else if (args[0].equalsIgnoreCase("QUEUE")) {
                 out.addAll(clients());
             }
         }
 
-        if(args.length == 2) {
+        if (args.length == 2) {
             if (args[0].equalsIgnoreCase("QUEUE")) {
                 out.addAll(asList("list", "remove"));
             } else if (args[0].equalsIgnoreCase("LIST")) {
@@ -675,13 +683,13 @@ public final class CommandProcess extends Command implements Serializable {
             }
         }
 
-        if(args.length == 3) {
-            if (args[3].equalsIgnoreCase("remove")) {
+        if (args.length == 3) {
+            if (args[2].equalsIgnoreCase("remove")) {
                 out.addAll(asList("SERVER", "PROXY"));
             }
         }
 
-        if(args.length == 4) {
+        if (args.length == 4) {
             if (args[3].equalsIgnoreCase("SERVER")) {
                 out.addAll(servers());
             } else if (args[3].equalsIgnoreCase("PROXY")) {
@@ -731,13 +739,4 @@ public final class CommandProcess extends Command implements Serializable {
         Collections.sort(out);
         return out;
     }
-
-    private List<String> clientSort(String name) {
-        List<String> out = new LinkedList<>();
-        out.addAll(clients());
-        out.remove(name);
-        Collections.sort(out);
-        return out;
-    }
-
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandScreen.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandScreen.java
@@ -4,6 +4,11 @@
 
 package systems.reformcloud.commands;
 
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
@@ -13,12 +18,6 @@ import systems.reformcloud.meta.info.ProxyInfo;
 import systems.reformcloud.meta.info.ServerInfo;
 import systems.reformcloud.utility.screen.ScreenSessionProvider;
 import systems.reformcloud.utility.screen.defaults.DefaultScreenHandler;
-
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 05.02.2019
@@ -248,7 +247,7 @@ public final class CommandScreen extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("SEVRER", "PROXY", "CLIENT", "EXECUTE",
                 "SWITCH", "LEAVE"));
         }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandScreen.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandScreen.java
@@ -16,6 +16,9 @@ import systems.reformcloud.utility.screen.defaults.DefaultScreenHandler;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 05.02.2019
@@ -240,4 +243,63 @@ public final class CommandScreen extends Command implements Serializable {
             }
         }
     }
+
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("SEVRER", "PROXY", "CLIENT", "EXECUTE",
+                "SWITCH", "LEAVE"));
+        }
+
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("SERVER")) {
+                out.addAll(servers());
+            } else if (args[0].equalsIgnoreCase("PROXY")) {
+                out.addAll(proxies());
+            } else if (args[0].equalsIgnoreCase("CLIENT")) {
+                out.addAll(clients());
+            } else if (args[0].equalsIgnoreCase("SWITCH")) {
+                out.addAll(asList("SEVRER", "PROXY", "CLIENT"));
+            }
+        }
+
+        if (args.length == 2) {
+            if (args[1].equalsIgnoreCase("SERVER")) {
+                out.addAll(servers());
+            } else if (args[1].equalsIgnoreCase("PROXY")) {
+                out.addAll(proxies());
+            } else if (args[1].equalsIgnoreCase("CLIENT")) {
+                out.addAll(clients());
+            }
+        }
+
+        return out;
+    }
+
+    private List<String> servers() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredServers()
+            .forEach(servers -> out.add(servers.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> proxies() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllRegisteredProxies()
+            .forEach(proxies -> out.add(proxies.getCloudProcess().getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandUpload.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandUpload.java
@@ -18,6 +18,9 @@ import java.io.Serializable;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * @author _Klaro | Pasqual K. / created on 08.03.2019
@@ -304,6 +307,30 @@ public final class CommandUpload extends Command implements Serializable {
         commandSender.sendMessage("upload <CONTROLLERADDON, CLIENTADDON> NAME URL");
     }
 
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("PLUGIN", "CONTROLLER", "CLIENTS",
+                "CONTROLLERADDON", "CLIENTADDON"));
+        }
+
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("PLUGIN")) {
+                out.addAll(groups());
+            }
+        }
+
+        if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("PLUGIN")) {
+                out.addAll(templates(args[1]));
+            }
+        }
+
+        return out;
+    }
+
     private boolean isURLValid(String url) {
         try {
             URLConnection urlConnection = new URL(url).openConnection();
@@ -318,4 +345,35 @@ public final class CommandUpload extends Command implements Serializable {
             return false;
         }
     }
+
+    private List<String> groups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllProxyGroups()
+            .forEach(group -> out.add(group.getName()));
+        ReformCloudController.getInstance().getAllServerGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> clients() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllConnectedClients()
+            .forEach(client -> out.add(client.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> templates(String name) {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getServerGroup(name)
+            .getTemplates()
+            .forEach(template -> out.add(template.getName()));
+        ReformCloudController.getInstance().getProxyGroup(name)
+            .getTemplates()
+            .forEach(template -> out.add(template.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandUpload.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandUpload.java
@@ -4,16 +4,6 @@
 
 package systems.reformcloud.commands;
 
-import systems.reformcloud.ReformCloudController;
-import systems.reformcloud.commands.utility.Command;
-import systems.reformcloud.commands.utility.CommandSender;
-import systems.reformcloud.meta.client.Client;
-import systems.reformcloud.meta.proxy.ProxyGroup;
-import systems.reformcloud.meta.server.ServerGroup;
-import systems.reformcloud.network.out.*;
-import systems.reformcloud.utility.files.DownloadManager;
-import systems.reformcloud.utility.files.FileUtils;
-
 import java.io.Serializable;
 import java.net.URL;
 import java.net.URLConnection;
@@ -21,6 +11,20 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import systems.reformcloud.ReformCloudController;
+import systems.reformcloud.commands.utility.Command;
+import systems.reformcloud.commands.utility.CommandSender;
+import systems.reformcloud.meta.client.Client;
+import systems.reformcloud.meta.proxy.ProxyGroup;
+import systems.reformcloud.meta.server.ServerGroup;
+import systems.reformcloud.network.out.PacketOutUpdateClientAddon;
+import systems.reformcloud.network.out.PacketOutUpdateClientFromURL;
+import systems.reformcloud.network.out.PacketOutUpdateProxyGroupPlugin;
+import systems.reformcloud.network.out.PacketOutUpdateProxyGroupPluginTemplate;
+import systems.reformcloud.network.out.PacketOutUpdateServerGroupPlugin;
+import systems.reformcloud.network.out.PacketOutUpdateServerGroupPluginTemplate;
+import systems.reformcloud.utility.files.DownloadManager;
+import systems.reformcloud.utility.files.FileUtils;
 
 /**
  * @author _Klaro | Pasqual K. / created on 08.03.2019
@@ -311,7 +315,7 @@ public final class CommandUpload extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("PLUGIN", "CONTROLLER", "CLIENTS",
                 "CONTROLLERADDON", "CLIENTADDON"));
         }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWebPermissions.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWebPermissions.java
@@ -10,6 +10,9 @@ import systems.reformcloud.commands.utility.CommandSender;
 import systems.reformcloud.meta.web.WebUser;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -104,6 +107,33 @@ public final class CommandWebPermissions extends Command implements Serializable
         }
     }
 
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if (args.length == 0) {
+            out.addAll(asList("ADD", "REMOVE", "LIST"));
+        }
+
+        if (args.length == 1) {
+            if (args[0].equalsIgnoreCase("LIST")) {
+                out.addAll(users());
+            }
+        }
+
+        if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("REMOVE")) {
+                out.addAll(userGetPermissions(args[1]));
+            }
+        }
+
+        if (args.length == 3) {
+            out.addAll(asList("TRUE", "FALSE"));
+        }
+
+        return out;
+    }
+
     private WebUser getUser(final String name) {
         return ReformCloudController.getInstance()
             .getCloudConfiguration()
@@ -113,4 +143,22 @@ public final class CommandWebPermissions extends Command implements Serializable
             .findFirst()
             .orElse(null);
     }
+
+    private List<String> users() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getCloudConfiguration()
+            .getWebUsers()
+            .forEach(user -> out.add(user.getUserName()));
+        Collections.sort(out);
+        return out;
+    }
+
+    private List<String> userGetPermissions(String name) {
+        List<String> out = new LinkedList<>();
+        this.getUser(name).getPermissions()
+            .forEach((permission, value) -> out.add(permission));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWebPermissions.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWebPermissions.java
@@ -4,16 +4,15 @@
 
 package systems.reformcloud.commands;
 
-import systems.reformcloud.ReformCloudController;
-import systems.reformcloud.commands.utility.Command;
-import systems.reformcloud.commands.utility.CommandSender;
-import systems.reformcloud.meta.web.WebUser;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import systems.reformcloud.ReformCloudController;
+import systems.reformcloud.commands.utility.Command;
+import systems.reformcloud.commands.utility.CommandSender;
+import systems.reformcloud.meta.web.WebUser;
 
 /**
  * @author _Klaro | Pasqual K. / created on 09.02.2019
@@ -115,16 +114,12 @@ public final class CommandWebPermissions extends Command implements Serializable
             out.addAll(asList("ADD", "REMOVE", "LIST"));
         }
 
-        if (args.length == 1) {
-            if (args[0].equalsIgnoreCase("LIST")) {
-                out.addAll(users());
-            }
+        if (args.length == 1 && args[0].equalsIgnoreCase("LIST")) {
+            out.addAll(users());
         }
 
-        if (args.length == 2) {
-            if (args[0].equalsIgnoreCase("REMOVE")) {
-                out.addAll(userGetPermissions(args[1]));
-            }
+        if (args.length == 2 && args[0].equalsIgnoreCase("REMOVE")) {
+            out.addAll(userGetPermissions(args[1]));
         }
 
         if (args.length == 3) {

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWhitelist.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWhitelist.java
@@ -4,19 +4,17 @@
 
 package systems.reformcloud.commands;
 
-import systems.reformcloud.ReformCloudController;
-import systems.reformcloud.ReformCloudLibraryService;
-import systems.reformcloud.commands.utility.Command;
-import systems.reformcloud.commands.utility.CommandSender;
-import systems.reformcloud.language.utility.Language;
-import systems.reformcloud.network.out.PacketOutUpdateAll;
-import systems.reformcloud.utility.uuid.UUIDConverter;
-
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+import systems.reformcloud.ReformCloudController;
+import systems.reformcloud.commands.utility.Command;
+import systems.reformcloud.commands.utility.CommandSender;
+import systems.reformcloud.language.utility.Language;
+import systems.reformcloud.network.out.PacketOutUpdateAll;
+import systems.reformcloud.utility.uuid.UUIDConverter;
 
 /**
  * @author _Klaro | Pasqual K. / created on 17.12.2018
@@ -162,7 +160,7 @@ public final class CommandWhitelist extends Command implements Serializable {
     public List<String> complete(String commandLine, String[] args) {
         List<String> out = new LinkedList<>();
 
-        if(args.length == 0) {
+        if (args.length == 0) {
             out.addAll(asList("ADD", "REMOVE", "LIST"));
         }
 

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWhitelist.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/commands/CommandWhitelist.java
@@ -5,6 +5,7 @@
 package systems.reformcloud.commands;
 
 import systems.reformcloud.ReformCloudController;
+import systems.reformcloud.ReformCloudLibraryService;
 import systems.reformcloud.commands.utility.Command;
 import systems.reformcloud.commands.utility.CommandSender;
 import systems.reformcloud.language.utility.Language;
@@ -12,6 +13,9 @@ import systems.reformcloud.network.out.PacketOutUpdateAll;
 import systems.reformcloud.utility.uuid.UUIDConverter;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -154,6 +158,36 @@ public final class CommandWhitelist extends Command implements Serializable {
         }
     }
 
+    @Override
+    public List<String> complete(String commandLine, String[] args) {
+        List<String> out = new LinkedList<>();
+
+        if(args.length == 0) {
+            out.addAll(asList("ADD", "REMOVE", "LIST"));
+        }
+
+        if(args.length == 1) {
+            if (args[0].equalsIgnoreCase("ADD")) {
+                out.addAll(proxyGroups());
+                out.addAll(asList("--all"));
+            } else if (args[0].equalsIgnoreCase("REMOVE")) {
+                out.addAll(proxyGroups());
+                out.addAll(asList("--all"));
+            }
+        }
+
+        if(args.length == 2) {
+            if (args[0].equalsIgnoreCase("ADD")) {
+                out.addAll(proxyGroups());
+            } else if (args[0].equalsIgnoreCase("REMOVE")) {
+                out.addAll(proxyGroups());
+            }
+        }
+
+        return out;
+    }
+
+
     private UUID getUuidFromString(String in) {
         try {
             UUID uuidInput;
@@ -168,4 +202,13 @@ public final class CommandWhitelist extends Command implements Serializable {
             return UUIDConverter.getUUIDFromName(in);
         }
     }
+
+    private List<String> proxyGroups() {
+        List<String> out = new LinkedList<>();
+        ReformCloudController.getInstance().getAllProxyGroups()
+            .forEach(group -> out.add(group.getName()));
+        Collections.sort(out);
+        return out;
+    }
+
 }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
@@ -325,7 +325,7 @@ public final class CloudConfiguration implements Serializable {
                 .addStringValue("internal-api-bungee-command-hub-already",
                     "%prefix% §7You are already connected to a hub server")
                 .addStringValue("internal-api-bungee-command-hub-not-available",
-                    "%prefix% §7There is now hub server available")
+                    "%prefix% §7There is no hub server available")
 
                 .addStringValue("internal-api-bungee-command-jumpto-server-player-not-found",
                     "%prefix% §cCould not find player or server to go to")

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/configuration/CloudConfiguration.java
@@ -14,7 +14,7 @@ import systems.reformcloud.configurations.Configuration;
 import systems.reformcloud.cryptic.StringEncrypt;
 import systems.reformcloud.language.LanguageManager;
 import systems.reformcloud.language.utility.Language;
-import systems.reformcloud.logging.ColouredConsoleProvider;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.meta.client.Client;
 import systems.reformcloud.meta.proxy.ProxyGroup;
 import systems.reformcloud.meta.proxy.defaults.DefaultProxyGroup;
@@ -133,7 +133,7 @@ public final class CloudConfiguration implements Serializable {
             return false;
         }
 
-        final ColouredConsoleProvider colouredConsoleProvider = ReformCloudController.getInstance()
+        final AbstractLoggerProvider colouredConsoleProvider = ReformCloudController.getInstance()
             .getColouredConsoleProvider();
 
         colouredConsoleProvider.info("Please enter a language [\"german\", \"english\"]");
@@ -684,7 +684,8 @@ public final class CloudConfiguration implements Serializable {
             .write(Paths.get("reformcloud/groups/proxies/" + group + ".json"));
     }
 
-    public String readString(final ColouredConsoleProvider colouredConsoleProvider, Predicate<String> checkable) {
+    public String readString(final AbstractLoggerProvider colouredConsoleProvider,
+                             Predicate<String> checkable) {
         String readLine = colouredConsoleProvider.readLine();
         while (readLine == null
             || !checkable.test(readLine)
@@ -696,7 +697,8 @@ public final class CloudConfiguration implements Serializable {
         return readLine;
     }
 
-    private Integer readInt(final ColouredConsoleProvider colouredConsoleProvider, Predicate<Integer> checkable) {
+    private Integer readInt(final AbstractLoggerProvider colouredConsoleProvider,
+                            Predicate<Integer> checkable) {
         String readLine = colouredConsoleProvider.readLine();
         while (readLine == null
             || readLine.trim().isEmpty()

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/database/statistics/StatisticsProvider.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/database/statistics/StatisticsProvider.java
@@ -5,15 +5,16 @@
 package systems.reformcloud.database.statistics;
 
 import com.google.gson.reflect.TypeToken;
+import systems.reformcloud.ReformCloudController;
+import systems.reformcloud.configurations.Configuration;
+import systems.reformcloud.meta.server.stats.TempServerStats;
+import systems.reformcloud.utility.files.FileUtils;
+
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import systems.reformcloud.ReformCloudController;
-import systems.reformcloud.configurations.Configuration;
-import systems.reformcloud.meta.server.stats.TempServerStats;
-import systems.reformcloud.utility.files.FileUtils;
 
 /**
  * @author _Klaro | Pasqual K. / created on 03.02.2019
@@ -48,9 +49,6 @@ public final class StatisticsProvider extends SaveStatisticsProvider implements 
             this.stats = Configuration.parse(Paths.get("reformcloud/database/stats/stats.json"))
                 .getValue("stats", new TypeToken<Stats>() {
                 }.getType());
-            ReformCloudController.getInstance().getColouredConsoleProvider().info()
-                .accept("Stats: " + Files.readAllBytes(Paths.get("reformcloud"
-                    + "/database/stats/stats.json")).length + " bytes OK");
         } catch (final Throwable throwable) {
             ReformCloudController.getInstance().getColouredConsoleProvider().serve()
                 .accept("Stats: 0 bytes OK");

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/network/in/PacketInClientProcessQueue.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/network/in/PacketInClientProcessQueue.java
@@ -7,7 +7,7 @@ package systems.reformcloud.network.in;
 import com.google.gson.reflect.TypeToken;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.configurations.Configuration;
-import systems.reformcloud.logging.ColouredConsoleProvider;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.meta.startup.ProxyStartupInfo;
 import systems.reformcloud.meta.startup.ServerStartupInfo;
 import systems.reformcloud.network.interfaces.NetworkInboundHandler;
@@ -23,7 +23,7 @@ public final class PacketInClientProcessQueue implements Serializable, NetworkIn
 
     @Override
     public void handle(Configuration configuration) {
-        final ColouredConsoleProvider colouredConsoleProvider = ReformCloudController.getInstance()
+        final AbstractLoggerProvider colouredConsoleProvider = ReformCloudController.getInstance()
             .getColouredConsoleProvider();
         colouredConsoleProvider
             .info("ProcessQueue of Client §3" + configuration.getStringValue("name") + ":");

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/network/in/PacketInClientProcessQueue.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/network/in/PacketInClientProcessQueue.java
@@ -40,7 +40,7 @@ public final class PacketInClientProcessQueue implements Serializable, NetworkIn
             colouredConsoleProvider.info("    There are §c0§r server processes in the §3Client§r queue");
         } else {
             servers.forEach(e -> colouredConsoleProvider.info(
-                "    - " + e.getName() + " | Group: " + e.getServerGroup().getName() + " | UID: "
+                "    - §e" + e.getName() + "§r | Group: §e" + e.getServerGroup().getName() + "§r | UID: §e"
                     + e.getUid()));
         }
 
@@ -51,7 +51,7 @@ public final class PacketInClientProcessQueue implements Serializable, NetworkIn
             colouredConsoleProvider.info("    There are §c0§r proxy processes in the §3Client§r queue");
         } else {
             proxies.forEach(e -> colouredConsoleProvider.info(
-                "    - " + e.getName() + " | Group: " + e.getProxyGroup().getName() + " | UID: " + e
+                "    - §e" + e.getName() + "§r | Group: §e" + e.getProxyGroup().getName() + "§r | UID: §e" + e
                     .getUid()));
         }
     }

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/network/query/out/PacketOutQueryGetOnlinePlayers.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/network/query/out/PacketOutQueryGetOnlinePlayers.java
@@ -1,0 +1,21 @@
+/*
+  Copyright © 2019 Pasqual K. | All rights reserved
+ */
+
+package systems.reformcloud.network.query.out;
+
+import java.io.Serializable;
+import systems.reformcloud.configurations.Configuration;
+import systems.reformcloud.network.packet.Packet;
+
+/**
+ * @author _Klaro | Pasqual K. / created on 02.07.2019
+ */
+
+public final class PacketOutQueryGetOnlinePlayers extends Packet implements Serializable {
+
+    public PacketOutQueryGetOnlinePlayers() {
+        super("GetOnlinePlayers", new Configuration());
+    }
+
+}

--- a/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/utility/player/PlayerLogoutHandler.java
+++ b/reformcloud-global/reformcloud-controller/src/main/java/systems/reformcloud/utility/player/PlayerLogoutHandler.java
@@ -11,6 +11,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import systems.reformcloud.ReformCloudController;
 import systems.reformcloud.ReformCloudLibraryService;
 import systems.reformcloud.event.events.PlayerDisconnectsEvent;
@@ -51,6 +52,8 @@ public final class PlayerLogoutHandler extends Thread implements Serializable {
                 if (currentOnline != null) {
                     proxyInfo.getOnlinePlayers().forEach(uuid -> {
                         if (!currentOnline.contains(uuid)) {
+                            ReformCloudController.getInstance().getColouredConsoleProvider()
+                                .serve().accept(uuid.toString());
                             forRemoval.add(uuid);
                             proxyInfo.setOnline(proxyInfo.getOnline() - 1);
                             proxyInfos.add(proxyInfo);
@@ -78,7 +81,7 @@ public final class PlayerLogoutHandler extends Thread implements Serializable {
                 proxyInfos.clear();
             }
 
-            ReformCloudLibraryService.sleep(900);
+            ReformCloudLibraryService.sleep(TimeUnit.SECONDS, 30);
         }
     }
 

--- a/reformcloud-library/pom.xml
+++ b/reformcloud-library/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-yaml</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
             <scope>provided</scope>
         </dependency>
 
@@ -66,7 +66,7 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 
     <build>

--- a/reformcloud-library/pom.xml
+++ b/reformcloud-library/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-yaml</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -66,7 +66,7 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 
     <build>

--- a/reformcloud-library/src/main/java/systems/reformcloud/ReformCloudLibraryService.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/ReformCloudLibraryService.java
@@ -26,21 +26,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.MultithreadEventExecutorGroup;
-import java.lang.management.ClassLoadingMXBean;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.RuntimeMXBean;
-import java.lang.management.ThreadMXBean;
-import java.util.Locale;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Predicate;
 import systems.reformcloud.api.AsyncAPI;
 import systems.reformcloud.cache.Cache;
 import systems.reformcloud.cache.CacheClearer;
@@ -56,6 +41,13 @@ import systems.reformcloud.network.handler.Encoder;
 import systems.reformcloud.network.length.LengthDecoder;
 import systems.reformcloud.network.length.LengthEncoder;
 import systems.reformcloud.utility.StringUtil;
+
+import java.lang.management.*;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 /**
  * @author _Klaro | Pasqual K. / created on 18.10.2018
@@ -78,7 +70,6 @@ public final class ReformCloudLibraryService {
         System.setProperty("io.netty.leakDetectionLevel", "DISABLED");
         System.setProperty("io.netty.recycler.maxCapacity", "0");
         System.setProperty("io.netty.recycler.maxCapacity.default", "0");
-        System.setProperty("io.netty.noPreferDirect", "true");
         System.setProperty("io.netty.allocator.type", "UNPOOLED");
     }
 

--- a/reformcloud-library/src/main/java/systems/reformcloud/ReformCloudLibraryServiceProvider.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/ReformCloudLibraryServiceProvider.java
@@ -8,12 +8,14 @@ import systems.reformcloud.event.abstracts.EventManager;
 import systems.reformcloud.exceptions.InstanceAlreadyExistsException;
 import systems.reformcloud.language.LanguageManager;
 import systems.reformcloud.language.utility.Language;
+import systems.reformcloud.logging.AbstractLoggerProvider;
 import systems.reformcloud.logging.ColouredConsoleProvider;
 import systems.reformcloud.meta.cluster.NetworkGlobalCluster;
 import systems.reformcloud.network.NettyHandler;
 import systems.reformcloud.network.abstracts.AbstractChannelHandler;
 import systems.reformcloud.network.channel.ChannelHandler;
 import systems.reformcloud.utility.cloudsystem.InternalCloudNetwork;
+import systems.reformcloud.utility.threading.AbstractTaskScheduler;
 import systems.reformcloud.utility.threading.TaskScheduler;
 
 import java.util.Objects;
@@ -52,12 +54,17 @@ public final class ReformCloudLibraryServiceProvider {
     /**
      * The logger provider of the cloud system
      */
-    private ColouredConsoleProvider colouredConsoleProvider;
+    private AbstractLoggerProvider colouredConsoleProvider;
 
     /**
-     * Some internal information about the controller
+     * The controller key
      */
-    private String key, controllerIP;
+    private String key;
+
+    /**
+     * The ip address of the controller
+     */
+    private String controllerIP;
 
     /**
      * The netty handler of the cloud
@@ -67,7 +74,7 @@ public final class ReformCloudLibraryServiceProvider {
     /**
      * The TaskScheduler of the cloud
      */
-    private TaskScheduler taskScheduler;
+    private AbstractTaskScheduler taskScheduler;
 
     /**
      * Creates a new Instance of the {ReformCloudLibraryServiceProvider}
@@ -116,7 +123,7 @@ public final class ReformCloudLibraryServiceProvider {
         return this.channelHandler;
     }
 
-    public ColouredConsoleProvider getColouredConsoleProvider() {
+    public AbstractLoggerProvider getColouredConsoleProvider() {
         return this.colouredConsoleProvider;
     }
 
@@ -132,7 +139,7 @@ public final class ReformCloudLibraryServiceProvider {
         return this.nettyHandler;
     }
 
-    public TaskScheduler getTaskScheduler() {
+    public AbstractTaskScheduler getTaskScheduler() {
         return this.taskScheduler;
     }
 

--- a/reformcloud-library/src/main/java/systems/reformcloud/addons/AddonParallelLoader.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/addons/AddonParallelLoader.java
@@ -102,7 +102,7 @@ public class AddonParallelLoader extends AddonLoader implements Serializable {
 
     @Override
     public boolean enableAddon(final String name) {
-        Set<AddonClassConfig> moduleConfigs = new HashSet<>();
+        Set<AddonClassConfig> addonClassConfigs = new HashSet<>();
 
         File[] files = new File("reformcloud/addons").listFiles(pathname ->
             pathname.isFile()
@@ -129,11 +129,11 @@ public class AddonParallelLoader extends AddonLoader implements Serializable {
                     jarFile.getInputStream(jarEntry), StandardCharsets.UTF_8)) {
                     Properties properties = new Properties();
                     properties.load(reader);
-                    AddonClassConfig moduleConfig = new AddonClassConfig(file,
+                    AddonClassConfig addonClassConfig = new AddonClassConfig(file,
                         properties.getProperty("name"),
                         properties.getProperty("version"),
                         properties.getProperty("mainClazz"));
-                    moduleConfigs.add(moduleConfig);
+                    addonClassConfigs.add(addonClassConfig);
                 }
             } catch (final Throwable throwable) {
                 StringUtil
@@ -142,7 +142,7 @@ public class AddonParallelLoader extends AddonLoader implements Serializable {
             }
         }
 
-        moduleConfigs.forEach(addonClassConfig -> {
+        addonClassConfigs.forEach(addonClassConfig -> {
             try {
                 final AddonMainClassLoader addonMainClassLoader = new AddonMainClassLoader(
                     addonClassConfig);
@@ -179,14 +179,14 @@ public class AddonParallelLoader extends AddonLoader implements Serializable {
     }
 
     private Set<AddonClassConfig> checkForAddons() {
-        Set<AddonClassConfig> moduleConfigs = new HashSet<>();
+        Set<AddonClassConfig> addonClassConfigs = new HashSet<>();
 
         File[] files = new File("reformcloud/addons").listFiles(pathname ->
             pathname.isFile()
                 && pathname.exists()
                 && pathname.getName().endsWith(".jar"));
         if (files == null) {
-            return moduleConfigs;
+            return addonClassConfigs;
         }
 
         for (File file : files) {
@@ -201,11 +201,11 @@ public class AddonParallelLoader extends AddonLoader implements Serializable {
                     jarFile.getInputStream(jarEntry), StandardCharsets.UTF_8)) {
                     Properties properties = new Properties();
                     properties.load(reader);
-                    AddonClassConfig moduleConfig = new AddonClassConfig(file,
+                    AddonClassConfig addonClassConfig = new AddonClassConfig(file,
                         properties.getProperty("name"),
                         properties.getProperty("version"),
                         properties.getProperty("mainClazz"));
-                    moduleConfigs.add(moduleConfig);
+                    addonClassConfigs.add(addonClassConfig);
                 }
             } catch (final Throwable throwable) {
                 StringUtil
@@ -214,7 +214,7 @@ public class AddonParallelLoader extends AddonLoader implements Serializable {
             }
         }
 
-        return moduleConfigs;
+        return addonClassConfigs;
     }
 
     @Override

--- a/reformcloud-library/src/main/java/systems/reformcloud/addons/dependency/DependencyLoader.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/addons/dependency/DependencyLoader.java
@@ -116,7 +116,7 @@ public final class DependencyLoader implements Serializable {
     }
 
     private static String format(final DynamicDependency dependency) {
-        return dependency.download_url + dependency.getGroupID().replace(".", "/") + "/" +
+        return dependency.downloadUrl + dependency.getGroupID().replace(".", "/") + "/" +
             dependency.getName() + "/" + dependency.getVersion() + "/" + dependency.getName() + "-"
             + dependency.getVersion() + ".jar";
     }

--- a/reformcloud-library/src/main/java/systems/reformcloud/addons/dependency/util/DynamicDependency.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/addons/dependency/util/DynamicDependency.java
@@ -17,7 +17,7 @@ public abstract class DynamicDependency implements Serializable {
     /**
      * The download url of the dependency
      */
-    public String download_url = "http://central.maven.org/maven2/";
+    public String downloadUrl = "http://central.maven.org/maven2/";
 
     /**
      * Creates a new dynamic dependency using the default url
@@ -34,7 +34,7 @@ public abstract class DynamicDependency implements Serializable {
      */
     protected DynamicDependency(final String url) {
         if (url != null) {
-            this.download_url = url.endsWith("/") ? url : url + "/";
+            this.downloadUrl = url.endsWith("/") ? url : url + "/";
         }
     }
 
@@ -59,7 +59,7 @@ public abstract class DynamicDependency implements Serializable {
      */
     public abstract String getVersion();
 
-    public String getDownload_url() {
-        return this.download_url;
+    public String getDownloadUrl() {
+        return this.downloadUrl;
     }
 }

--- a/reformcloud-library/src/main/java/systems/reformcloud/api/APIService.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/api/APIService.java
@@ -4,13 +4,6 @@
 
 package systems.reformcloud.api;
 
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import systems.reformcloud.api.permissions.PermissionHelper;
 import systems.reformcloud.api.save.SaveAPIService;
 import systems.reformcloud.configurations.Configuration;
@@ -35,6 +28,10 @@ import systems.reformcloud.network.packet.PacketFuture;
 import systems.reformcloud.player.implementations.OfflinePlayer;
 import systems.reformcloud.player.implementations.OnlinePlayer;
 import systems.reformcloud.utility.annotiations.MayNotBePresent;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author _Klaro | Pasqual K. / created on 17.02.2019
@@ -292,6 +289,38 @@ public interface APIService extends Serializable, SnapshotAble {
      * @param serverGroup The server group which should be updated
      */
     void updateServerGroup(ServerGroup serverGroup);
+
+    /**
+     * Updates a specific server name
+     *
+     * @param serverInfo The server info of the server which should be updated
+     * @param newName    The new name of the server
+     */
+    void updateServerName(ServerInfo serverInfo, String newName);
+
+    /**
+     * Updates a specific server name
+     *
+     * @param serverName The server name of the server which should be updated
+     * @param newName    The new name of the server
+     */
+    void updateServerName(String serverName, String newName);
+
+    /**
+     * Updates a specific proxy name
+     *
+     * @param proxyInfo The proxy info of the proxy which should be updated
+     * @param newName   The new name of the proxy
+     */
+    void updateProxyName(ProxyInfo proxyInfo, String newName);
+
+    /**
+     * Updates a specific proxy name
+     *
+     * @param proxyName The proxy name of the proxy which should be updated
+     * @param newName   The new name of the proxy
+     */
+    void updateProxyName(String proxyName, String newName);
 
     /**
      * Updates a specific proxy group

--- a/reformcloud-library/src/main/java/systems/reformcloud/api/permissions/PermissionHelper.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/api/permissions/PermissionHelper.java
@@ -4,18 +4,19 @@
 
 package systems.reformcloud.api.permissions;
 
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import systems.reformcloud.player.permissions.PermissionCache;
 import systems.reformcloud.player.permissions.group.PermissionGroup;
 import systems.reformcloud.player.permissions.player.PermissionHolder;
 import systems.reformcloud.utility.Require;
 import systems.reformcloud.utility.annotiations.MayNotBePresent;
 import systems.reformcloud.utility.annotiations.ShouldNotBeNull;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author _Klaro | Pasqual K. / created on 28.06.2019
@@ -226,7 +227,7 @@ public interface PermissionHelper extends Serializable {
         executeCommand("perms " + group + " setprefix " + newPrefix);
     }
 
-    default void setGroupDiscplay(String group, String newDisplay) {
+    default void setGroupDisplay(String group, String newDisplay) {
         Require.requireNotNull(group);
         Require.requireNotNull(newDisplay);
 

--- a/reformcloud-library/src/main/java/systems/reformcloud/language/languages/defaults/German.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/language/languages/defaults/German.java
@@ -28,7 +28,7 @@ public final class German extends Language implements Serializable {
             "Lösche ServerGruppe §e[Name=%name%/Clients=%clients%]§r...",
             "Lösche ProxyGruppe §e[Name=%name%/Clients=%clients%]§r...",
             "Lösche Client §e[Name=%name%/IP=%ip%]§r...",
-            "Das Icon der ProxyGruppe %group% ist nicht 64x64 Pixel groß. Bitte behebe den Fehler, denn sonst kann dein Icon nicht geladen werden",
+            "Das Icon der ProxyGruppe §e%group%§r ist nicht §e64x64 Pixel§r groß. Bitte behebe den Fehler, denn sonst kann dein Icon nicht geladen werden",
             "§cEine neue Version von §aReformCloud §cist verfügbar",
             "Deine Version ist §aauf dem neustem Stand",
             "ServerProzess §e%name%§r wurde §cgestoppt",

--- a/reformcloud-library/src/main/java/systems/reformcloud/logging/AbstractLoggerProvider.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/logging/AbstractLoggerProvider.java
@@ -8,6 +8,7 @@ import jline.console.ConsoleReader;
 import systems.reformcloud.logging.handlers.IConsoleInputHandler;
 
 import java.io.Serializable;
+import java.text.DateFormat;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -168,6 +169,34 @@ public abstract class AbstractLoggerProvider implements Serializable {
      * @return the current console reader of the cloud
      */
     public abstract ConsoleReader consoleReader();
+
+    /**
+     * Sets the current controller time
+     *
+     * @param time The current time of the controller
+     */
+    public abstract void setControllerTime(long time);
+
+    /**
+     * Sets the new debug state
+     *
+     * @param enabled If the debug should be enabled or not
+     */
+    public abstract void setDebug(boolean enabled);
+
+    /**
+     * Checks if debug is enabled
+     *
+     * @return if debug is enabled
+     */
+    public abstract boolean isDebug();
+
+    /**
+     * Get the current cloud date format
+     *
+     * @return the current cloud date format
+     */
+    public abstract DateFormat getDateFormat();
 
     /**
      * Creates a new logger

--- a/reformcloud-library/src/main/java/systems/reformcloud/logging/ColouredConsoleProvider.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/logging/ColouredConsoleProvider.java
@@ -16,6 +16,7 @@ import systems.reformcloud.logging.enums.AnsiColourHandler;
 import systems.reformcloud.logging.handlers.IConsoleInputHandler;
 import systems.reformcloud.utility.Require;
 import systems.reformcloud.utility.StringUtil;
+import systems.reformcloud.utility.annotiations.ForRemoval;
 import systems.reformcloud.utility.files.DownloadManager;
 import systems.reformcloud.utility.runtime.Reload;
 import systems.reformcloud.utility.runtime.Shutdown;
@@ -473,10 +474,13 @@ public class ColouredConsoleProvider extends AbstractLoggerProvider implements S
         return this.consoleReader;
     }
 
+    @Deprecated
+    @ForRemoval
     public ConsoleReader getConsoleReader() {
         return this.consoleReader;
     }
 
+    @Override
     public DateFormat getDateFormat() {
         return this.dateFormat;
     }
@@ -493,6 +497,7 @@ public class ColouredConsoleProvider extends AbstractLoggerProvider implements S
         return this.controllerTime;
     }
 
+    @Override
     public boolean isDebug() {
         return this.debug;
     }
@@ -501,10 +506,12 @@ public class ColouredConsoleProvider extends AbstractLoggerProvider implements S
         return this.iConsoleInputHandlers;
     }
 
+    @Override
     public void setControllerTime(long controllerTime) {
         this.controllerTime = controllerTime;
     }
 
+    @Override
     public void setDebug(boolean debug) {
         this.debug = debug;
     }

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/CloudProcess.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/CloudProcess.java
@@ -101,28 +101,4 @@ public class CloudProcess implements Serializable {
     public void setName(String name) {
         this.name = name;
     }
-
-    public void setProcessUID(UUID processUID) {
-        this.processUID = processUID;
-    }
-
-    public void setClient(String client) {
-        this.client = client;
-    }
-
-    public void setGroup(String group) {
-        this.group = group;
-    }
-
-    public void setPreConfig(Configuration preConfig) {
-        this.preConfig = preConfig;
-    }
-
-    public void setLoadedTemplate(Template loadedTemplate) {
-        this.loadedTemplate = loadedTemplate;
-    }
-
-    public void setProcessID(int processID) {
-        this.processID = processID;
-    }
 }

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/proxy/versions/ProxyVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/proxy/versions/ProxyVersions.java
@@ -47,7 +47,9 @@ public enum ProxyVersions implements Serializable {
         return proxyProviders.name().toLowerCase() + ".jar";
     }
 
-    private String name, url;
+    private final String name;
+
+    private final String url;
 
     ProxyVersions(final String name, final String url) {
         this.name = name;

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/ServerGroup.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/ServerGroup.java
@@ -102,13 +102,18 @@ public class ServerGroup implements Serializable {
      */
     private SpigotVersions spigotVersions;
 
+    /*
+    * The only proxy join state of the group
+     */
+    private boolean onlyProxyJoin;
+
     @java.beans.ConstructorProperties({"name", "motd", "joinPermission", "clients", "templates",
         "memory", "minOnline", "maxOnline", "maxPlayers", "startPort", "maintenance", "saveLogs",
-        "autoStart", "autoStop", "serverModeType", "spigotVersions"})
+        "autoStart", "autoStop", "serverModeType", "spigotVersions", "onlyProxyJoin"})
     public ServerGroup(String name, String motd, String joinPermission, List<String> clients,
         List<Template> templates, int memory, int minOnline, int maxOnline, int maxPlayers,
         int startPort, boolean maintenance, boolean saveLogs, AutoStart autoStart,
-        AutoStop autoStop, ServerModeType serverModeType, SpigotVersions spigotVersions) {
+        AutoStop autoStop, ServerModeType serverModeType, SpigotVersions spigotVersions, boolean onlyProxyJoin) {
         this.name = name;
         this.motd = motd;
         this.joinPermission = joinPermission;
@@ -125,6 +130,7 @@ public class ServerGroup implements Serializable {
         this.autoStop = autoStop;
         this.serverModeType = serverModeType;
         this.spigotVersions = spigotVersions;
+        this.onlyProxyJoin = onlyProxyJoin;
     }
 
     public Template getTemplate(final String name) {
@@ -207,6 +213,10 @@ public class ServerGroup implements Serializable {
         return this.saveLogs;
     }
 
+    public boolean isOnlyProxyJoin() {
+        return onlyProxyJoin;
+    }
+
     public ServerModeType getServerModeType() {
         return this.serverModeType;
     }
@@ -261,6 +271,10 @@ public class ServerGroup implements Serializable {
 
     public void setSaveLogs(boolean saveLogs) {
         this.saveLogs = saveLogs;
+    }
+
+    public void setOnlyProxyJoin(boolean onlyProxyJoin) {
+        this.onlyProxyJoin = onlyProxyJoin;
     }
 
     public void setServerModeType(ServerModeType serverModeType) {

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/defaults/DefaultGroup.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/defaults/DefaultGroup.java
@@ -49,7 +49,8 @@ public class DefaultGroup extends ServerGroup implements Serializable {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             serverModeType,
-            spigotVersions
+            spigotVersions,
+            true
         );
     }
 }

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/defaults/LobbyGroup.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/defaults/LobbyGroup.java
@@ -48,7 +48,8 @@ public class LobbyGroup extends ServerGroup implements Serializable {
             new AutoStart(true, 45, TimeUnit.MINUTES.toSeconds(20)),
             new AutoStop(true, TimeUnit.MINUTES.toSeconds(5)),
             ServerModeType.LOBBY,
-            spigotVersions
+            spigotVersions,
+            true
         );
     }
 

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
@@ -69,8 +69,8 @@ public enum SpigotVersions implements Serializable {
         "https://mcmirror.io/grab/Spigot/Spigot-1.14.1-03bd4b0-20190520-1053.jar"),
     SPIGOT_1_14_2("Spigot 1.14.2", "1.14.2", 
         "https://mcmirror.io/grab/Spigot/Spigot-1.14.2-baafee9-20190602-0956.jar"),
-    SPIGOT_1_14_3("Spigot 1.14.3", "1.14.3", 
-        "https://mcmirror.io/grab/Spigot/Spigot-1.14.3-595711b-20190625-1057.jar"),    
+    SPIGOT_1_14_3("Spigot 1.14.3", "1.14.3",
+        "https://mcmirror.io/files/Spigot/Spigot-1.14.3-d05d3c1-20190703-0030.jar"),
 
     /**
      * Paper Versions
@@ -101,8 +101,8 @@ public enum SpigotVersions implements Serializable {
         "https://yivesmirror.com/files/paper/Paper-1.14.1-b42.jar"),
     PAPER_1_14_2("Paper 1.14.2", "1.14.2", 
         "https://mcmirror.io/grab/Paper/Paper-1.14.2-bf1d217-20190624-0232.jar"),
-    PAPER_1_14_3("Paper 1.14.3", "1.14.3", 
-        "https://mcmirror.io/grab/Paper/Paper-1.14.3-3042442-20190625-1355.jar"),    
+    PAPER_1_14_3("Paper 1.14.3", "1.14.3",
+        "https://mcmirror.io/files/Paper/Paper-1.14.3-1bacdbd-20190702-1850.jar"),
 
     /**
      * SpongeVanilla Versions

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
@@ -71,6 +71,8 @@ public enum SpigotVersions implements Serializable {
         "https://mcmirror.io/files/Spigot/Spigot-1.14.2-baafee9-20190602-0956.jar"),
     SPIGOT_1_14_3("Spigot 1.14.3", "1.14.3",
         "https://mcmirror.io/files/Spigot/Spigot-1.14.3-d05d3c1-20190703-0030.jar"),
+    SPIGOT_1_14_4("Spigot 1.14.4", "1.14.4",
+        "https://mcmirror.io/files/Spigot/Spigot-1.14.4-9de398a-20190719-2300.jar"),    
 
     /**
      * Paper Versions
@@ -103,6 +105,8 @@ public enum SpigotVersions implements Serializable {
         "https://mcmirror.io/files/Paper/Paper-1.14.2-bf1d217-20190624-0232.jar"),
     PAPER_1_14_3("Paper 1.14.3", "1.14.3",
         "https://mcmirror.io/files/Paper/Paper-1.14.3-1bacdbd-20190702-1850.jar"),
+    PAPER_1_14_4("Paper 1.14.4", "1.14.4",
+        "https://mcmirror.io/files/Paper/Paper-1.14.4-9fe63a1-20190720-0401.jar"),    
 
     /**
      * SpongeVanilla Versions
@@ -213,7 +217,8 @@ public enum SpigotVersions implements Serializable {
                     "1.14",
                     "1.14.1",
                     "1.14.2",
-                    "1.14.3"
+                    "1.14.3",
+                    "1.14.4"                    
                 ));
             }
         }

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
@@ -66,9 +66,9 @@ public enum SpigotVersions implements Serializable {
     SPIGOT_1_14("Spigot 1.14", "1.14",
         "https://mcmirror.io/files/Spigot/Spigot-1.14-8043ebc-20190514-0000.jar"),
     SPIGOT_1_14_1("Spigot 1.14.1", "1.14.1", 
-        "https://mcmirror.io/grab/Spigot/Spigot-1.14.1-03bd4b0-20190520-1053.jar"),
+        "https://mcmirror.io/files/Spigot/Spigot-1.14.1-03bd4b0-20190520-1053.jar"),
     SPIGOT_1_14_2("Spigot 1.14.2", "1.14.2", 
-        "https://mcmirror.io/grab/Spigot/Spigot-1.14.2-baafee9-20190602-0956.jar"),
+        "https://mcmirror.io/files/Spigot/Spigot-1.14.2-baafee9-20190602-0956.jar"),
     SPIGOT_1_14_3("Spigot 1.14.3", "1.14.3",
         "https://mcmirror.io/files/Spigot/Spigot-1.14.3-d05d3c1-20190703-0030.jar"),
 
@@ -100,7 +100,7 @@ public enum SpigotVersions implements Serializable {
     PAPER_1_14_1("Paper 1.14.1", "1.14.1", 
         "https://yivesmirror.com/files/paper/Paper-1.14.1-b42.jar"),
     PAPER_1_14_2("Paper 1.14.2", "1.14.2", 
-        "https://mcmirror.io/grab/Paper/Paper-1.14.2-bf1d217-20190624-0232.jar"),
+        "https://mcmirror.io/files/Paper/Paper-1.14.2-bf1d217-20190624-0232.jar"),
     PAPER_1_14_3("Paper 1.14.3", "1.14.3",
         "https://mcmirror.io/files/Paper/Paper-1.14.3-1bacdbd-20190702-1850.jar"),
 

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
@@ -5,11 +5,7 @@
 package systems.reformcloud.meta.server.versions;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
@@ -243,7 +239,11 @@ public enum SpigotVersions implements Serializable {
         return SpigotVersions.name.toLowerCase().replace(" ", "-") + ".jar";
     }
 
-    private final String name, version, url;
+    private final String name;
+
+    private final String version;
+
+    private final String url;
 
     SpigotVersions(final String name, final String version, final String url) {
         this.name = name;

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
@@ -108,7 +108,9 @@ public enum SpigotVersions implements Serializable {
      * SpongeVanilla Versions
      */
     SPONGEVANILLA_1_8_9("SpongeVanilla 1.8.9", "1.8.9",
-        "https://archive.mcmirror.io/SpongeVanilla/spongevanilla-1.8.9-4.2.0-BETA-352.jar"),    
+        "https://archive.mcmirror.io/SpongeVanilla/spongevanilla-1.8.9-4.2.0-BETA-352.jar"),   
+    SPONGEVANILLA_1_9_4("SpongeVanilla 1.9.4", "1.9.4",
+        "https://repo.spongepowered.org/maven/org/spongepowered/spongevanilla/1.9.4-5.0.0-BETA-83/spongevanilla-1.9.4-5.0.0-BETA-83.jar"),    
     SPONGEVANILLA_1_10_2("SpongeVanilla 1.10.2", "1.10.2",
         "https://archive.mcmirror.io/SpongeVanilla/spongevanilla-1.10.2-5.2.0-BETA-403.jar"),
     SPONGEVANILLA_1_11_2("SpongeVanilla 1.11.2", "1.11.2",

--- a/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/meta/server/versions/SpigotVersions.java
@@ -185,6 +185,7 @@ public enum SpigotVersions implements Serializable {
 
             if (!AVAILABLE_VERSIONS.contains(SpigotVersions.version)) {
                 AVAILABLE_VERSIONS.addAll(Arrays.asList(
+                    "1.7.9",
                     "1.7.10",
                     "1.8",
                     "1.8.3",

--- a/reformcloud-library/src/main/java/systems/reformcloud/network/channel/ChannelHandler.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/network/channel/ChannelHandler.java
@@ -184,6 +184,11 @@ public final class ChannelHandler extends AbstractChannelHandler implements Seri
             return;
         }
 
+        ReformCloudLibraryServiceProvider.getInstance().getColouredConsoleProvider()
+            .debug("Sending packet [Type=" + packet.getType() + "/Message=" + packet.getConfiguration().getJsonString()
+                + "/Size=" + packet.getConfiguration().getJsonString().getBytes().length
+                + "/To=" + this.getChannelNameByValue(channelHandlerContext) + "]");
+
         if (channelHandlerContext.channel().eventLoop().inEventLoop()) {
             channelHandlerContext.channel()
                 .writeAndFlush(packet).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);

--- a/reformcloud-library/src/main/java/systems/reformcloud/network/channel/ChannelReader.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/network/channel/ChannelReader.java
@@ -51,7 +51,7 @@ public final class ChannelReader extends SimpleChannelInboundHandler implements 
         ReformCloudLibraryServiceProvider.getInstance().getColouredConsoleProvider()
             .debug("Handling incoming packet " +
                 "[Type=" + packet.getType() + "/Query=" + (packet.getResult() != null) + "/Message="
-                + packet.getConfiguration());
+                + packet.getConfiguration().getJsonString() + "/Size=" + packet.getConfiguration().getJsonString().getBytes().length);
 
         IncomingPacketEvent incomingPacketEvent = new IncomingPacketEvent(packet,
             channelHandlerContext);

--- a/reformcloud-library/src/main/java/systems/reformcloud/player/version/SpigotVersion.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/player/version/SpigotVersion.java
@@ -9,6 +9,7 @@ import java.util.Map;
  */
 
 public enum SpigotVersion implements Serializable {
+    V1_14_4(498),    
     V1_14_3(490),
     V1_14_2(485),
     V1_14_1(480),

--- a/reformcloud-library/src/main/java/systems/reformcloud/utility/StringUtil.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/utility/StringUtil.java
@@ -22,9 +22,9 @@ public final class StringUtil {
         SLASH = "/",
         BACK_SLASH = "\\",
     //API Names: Version Specification date time B(ungee) S(igot) V(elocity)
-    BUNGEE_API_DOWNLOAD = "1121PRESTABLE02071945B",
-        SPIGOT_API_DOWNLOAD = "1121PRESTABLE02071945S",
-        VELOCITY_API_DOWNLOAD = "1121PRESTABLE02071945V",
+    BUNGEE_API_DOWNLOAD = "113PRESTABLE290719953B",
+        SPIGOT_API_DOWNLOAD = "113PRESTABLE290719953S",
+        VELOCITY_API_DOWNLOAD = "113PRESTABLE290719953V",
         NULL = "null",
         OS_NAME = System.getProperty("os.name"),
         OS_ARCH = System.getProperty("os.arch"),

--- a/reformcloud-library/src/main/java/systems/reformcloud/utility/StringUtil.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/utility/StringUtil.java
@@ -22,9 +22,9 @@ public final class StringUtil {
         SLASH = "/",
         BACK_SLASH = "\\",
     //API Names: Version Specification date time B(ungee) S(igot) V(elocity)
-    BUNGEE_API_DOWNLOAD = "112PRESTABLE07062349B",
-        SPIGOT_API_DOWNLOAD = "112PRESTABLE07062349S",
-        VELOCITY_API_DOWNLOAD = "112PRESTABLE07062349V",
+    BUNGEE_API_DOWNLOAD = "1121PRESTABLE02071945B",
+        SPIGOT_API_DOWNLOAD = "1121PRESTABLE02071945S",
+        VELOCITY_API_DOWNLOAD = "1121PRESTABLE02071945V",
         NULL = "null",
         OS_NAME = System.getProperty("os.name"),
         OS_ARCH = System.getProperty("os.arch"),

--- a/reformcloud-library/src/main/java/systems/reformcloud/utility/threading/AbstractTaskScheduler.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/utility/threading/AbstractTaskScheduler.java
@@ -1,0 +1,31 @@
+/*
+  Copyright © 2019 Pasqual K. | All rights reserved
+ */
+
+package systems.reformcloud.utility.threading;
+
+import java.io.Serializable;
+
+/**
+ * @author _Klaro | Pasqual K. / created on 21.07.2019
+ */
+
+public abstract class AbstractTaskScheduler implements Serializable {
+
+    /**
+     * Schedules a specific runnable in the given time
+     *
+     * @param arg1 The runnable which should be executed
+     * @param arg2 The repeats or {@code -1} to repeat forever
+     * @param arg3 The delay time in milliseconds
+     * @return The current class instance
+     */
+    public abstract AbstractTaskScheduler schedule(Runnable arg1,
+                                                   long arg2,
+                                                   long arg3);
+
+    /**
+     * Closes all running tasks
+     */
+    public abstract void close();
+}

--- a/reformcloud-library/src/main/java/systems/reformcloud/utility/threading/TaskScheduler.java
+++ b/reformcloud-library/src/main/java/systems/reformcloud/utility/threading/TaskScheduler.java
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
  * @author _Klaro | Pasqual K. / created on 28.03.2019
  */
 
-public final class TaskScheduler implements Serializable {
+public final class TaskScheduler extends AbstractTaskScheduler implements Serializable {
 
     /**
      * The default scheduler initialized by the cloud system
@@ -28,7 +28,8 @@ public final class TaskScheduler implements Serializable {
             .addShutdownHook(new Thread(() -> TASKS.forEach(TaskQueueEntry::delete)));
     }
 
-    public TaskScheduler schedule(Runnable runnable, long repeats, long timePerRepeat) {
+    @Override
+    public AbstractTaskScheduler schedule(Runnable runnable, long repeats, long timePerRepeat) {
         Runnable prepared = () -> {
             runnable.run();
             ReformCloudLibraryService.sleep(timePerRepeat);
@@ -40,6 +41,7 @@ public final class TaskScheduler implements Serializable {
         return this;
     }
 
+    @Override
     public void close() {
         this.TASKS.forEach(TaskQueueEntry::delete);
     }

--- a/reformcloud-pre-loader/pom.xml
+++ b/reformcloud-pre-loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/reformcloud-pre-loader/pom.xml
+++ b/reformcloud-pre-loader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-parent</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-client/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-client/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-pre-loader-common</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 
     <build>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-client/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-client/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-pre-loader-common</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 
     <build>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-client/src/main/java/systems/reformcloud/ClientPreLoader.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-client/src/main/java/systems/reformcloud/ClientPreLoader.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 final class ClientPreLoader implements Serializable {
 
     public static synchronized void main(String[] args) throws IOException {
-        LibraryPreLoader.prepareDependencies(true);
+        LibraryPreLoader.prepareDependencies(true, true);
         List<URL> libs = LibraryPreLoader.downloadDependencies();
         System.out.println("\nSuccessfully installed all necessary libraries");
 

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/CommonLoader.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/CommonLoader.java
@@ -4,6 +4,8 @@
 
 package systems.reformcloud;
 
+import systems.reformcloud.loader.CapableClassLoader;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -14,7 +16,6 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import systems.reformcloud.loader.CapableClassLoader;
 
 /**
  * @author _Klaro | Pasqual K. / created on 14.05.2019
@@ -33,12 +34,7 @@ final class CommonLoader implements Serializable {
         return createClassLoader(urls.toArray(new URL[0]));
     }
 
-    public static ClassLoader createClassLoader(URL urls) {
-        checkNonNull(urls);
-        return createClassLoader(new URL[]{urls});
-    }
-
-    public static ClassLoader createClassLoader(URL[] urls) {
+    private static ClassLoader createClassLoader(URL[] urls) {
         checkNonNull(urls);
         return new CapableClassLoader(urls, ClassLoader.getSystemClassLoader());
     }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/LibraryPreLoader.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/LibraryPreLoader.java
@@ -57,7 +57,8 @@ final class LibraryPreLoader implements Serializable {
         return downloaded;
     }
 
-    public static void prepareDependenciesVersions(boolean update, boolean installNetty) throws IOException {
+    private static void prepareDependenciesVersions(boolean update,
+                                                    boolean installNetty) throws IOException {
         if (update || !Files.exists(Paths.get("libraries/versions.properties"))) {
             if (Files.exists(Paths.get("libraries/versions.properties"))) {
                 Files.delete(Paths.get("libraries/versions.properties"));
@@ -165,8 +166,8 @@ final class LibraryPreLoader implements Serializable {
      * @return A string usable as download url for the lib
      */
     private static String format(final Dependency dependency) {
-        return dependency.download_url + dependency.getGroupID().replace(".", "/") + "/" +
-            dependency.getName() + "/" + dependency.getVersion() + "/" + dependency.getName() + "-"
+        return dependency.downloadUrl() + dependency.getGroupID().replace(".", "/") +
+            "/" + dependency.getName() + "/" + dependency.getVersion() + "/" + dependency.getName() + "-"
             + dependency.getVersion() + ".jar";
     }
 

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheCommonsNet.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheCommonsNet.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 public final class ApacheCommonsNet extends Dependency implements Serializable {
 
     public ApacheCommonsNet() {
-        super(null);
+        super(null, "3.6");
     }
 
     @Override
@@ -26,16 +26,5 @@ public final class ApacheCommonsNet extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "commons-net";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheCommonsNet.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheCommonsNet.java
@@ -30,6 +30,12 @@ public final class ApacheCommonsNet extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "3.6";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpComponents.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpComponents.java
@@ -32,6 +32,12 @@ public final class ApacheHttpComponents extends Dependency implements Serializab
 
     @Override
     public String getVersion() {
-        return "4.5.8";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpComponents.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpComponents.java
@@ -17,7 +17,7 @@ public final class ApacheHttpComponents extends Dependency implements Serializab
     private static final long serialVersionUID = -2104235898343838977L;
 
     public ApacheHttpComponents() {
-        super(null);
+        super(null, "4.5.9");
     }
 
     @Override
@@ -28,16 +28,5 @@ public final class ApacheHttpComponents extends Dependency implements Serializab
     @Override
     public String getName() {
         return "httpclient";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpCore.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpCore.java
@@ -32,6 +32,12 @@ public final class ApacheHttpCore extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "4.4.11";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpCore.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/ApacheHttpCore.java
@@ -17,7 +17,7 @@ public final class ApacheHttpCore extends Dependency implements Serializable {
     private static final long serialVersionUID = 727304906145669453L;
 
     public ApacheHttpCore() {
-        super(null);
+        super(null, "4.4.11");
     }
 
     @Override
@@ -28,16 +28,5 @@ public final class ApacheHttpCore extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "httpcore";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsCodec.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsCodec.java
@@ -30,6 +30,12 @@ public final class CommonsCodec extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "1.12";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsCodec.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsCodec.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 public final class CommonsCodec extends Dependency implements Serializable {
 
     public CommonsCodec() {
-        super(null);
+        super(null, "1.12");
     }
 
     @Override
@@ -26,16 +26,5 @@ public final class CommonsCodec extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "commons-codec";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsIO.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsIO.java
@@ -17,7 +17,7 @@ public final class CommonsIO extends Dependency implements Serializable {
     private static final long serialVersionUID = 8266556935851895180L;
 
     public CommonsIO() {
-        super(null);
+        super(null, "2.6");
     }
 
     @Override
@@ -28,16 +28,5 @@ public final class CommonsIO extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "commons-io";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsIO.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsIO.java
@@ -32,6 +32,12 @@ public final class CommonsIO extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "2.6";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsLogging.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsLogging.java
@@ -30,6 +30,12 @@ public final class CommonsLogging extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "1.2";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsLogging.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/CommonsLogging.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 public final class CommonsLogging extends Dependency implements Serializable {
 
     public CommonsLogging() {
-        super(null);
+        super(null, "1.2");
     }
 
     @Override
@@ -26,16 +26,5 @@ public final class CommonsLogging extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "commons-logging";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Gson.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Gson.java
@@ -32,6 +32,12 @@ public final class Gson extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "2.8.5";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Gson.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Gson.java
@@ -17,7 +17,7 @@ public final class Gson extends Dependency implements Serializable {
     private static final long serialVersionUID = -6226344132999747554L;
 
     public Gson() {
-        super(null);
+        super(null, "2.8.5");
     }
 
     @Override
@@ -28,16 +28,5 @@ public final class Gson extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "gson";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/JLine.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/JLine.java
@@ -17,7 +17,7 @@ public final class JLine extends Dependency implements Serializable {
     private static final long serialVersionUID = -5341268101711897840L;
 
     public JLine() {
-        super(null);
+        super(null, "2.14.6");
     }
 
     @Override
@@ -28,16 +28,5 @@ public final class JLine extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "jline";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/JLine.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/JLine.java
@@ -32,6 +32,12 @@ public final class JLine extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "2.14.6";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Netty.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Netty.java
@@ -4,9 +4,8 @@
 
 package systems.reformcloud.libraries;
 
-import systems.reformcloud.utility.Dependency;
-
 import java.io.Serializable;
+import systems.reformcloud.utility.Dependency;
 
 /**
  * @author _Klaro | Pasqual K. / created on 22.01.2019
@@ -32,6 +31,6 @@ public final class Netty extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "4.1.36.Final";
+        return "4.1.37.Final";
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Netty.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Netty.java
@@ -4,8 +4,9 @@
 
 package systems.reformcloud.libraries;
 
-import java.io.Serializable;
 import systems.reformcloud.utility.Dependency;
+
+import java.io.Serializable;
 
 /**
  * @author _Klaro | Pasqual K. / created on 22.01.2019
@@ -16,7 +17,7 @@ public final class Netty extends Dependency implements Serializable {
     private static final long serialVersionUID = 5273979933426169372L;
 
     public Netty() {
-        super(null);
+        super(null, "4.1.38.Final");
     }
 
     @Override
@@ -27,16 +28,5 @@ public final class Netty extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "netty-all";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Netty.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/Netty.java
@@ -31,6 +31,12 @@ public final class Netty extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "4.1.37.Final";
+        return version;
+    }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/SnakeYaml.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/SnakeYaml.java
@@ -32,4 +32,10 @@ public final class SnakeYaml extends Dependency implements Serializable {
     public String getVersion() {
         return "1.24";
     }
+
+    @Override
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
+    }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/SnakeYaml.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/SnakeYaml.java
@@ -30,7 +30,7 @@ public final class SnakeYaml extends Dependency implements Serializable {
 
     @Override
     public String getVersion() {
-        return "1.24";
+        return version;
     }
 
     @Override

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/SnakeYaml.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/libraries/SnakeYaml.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
 public final class SnakeYaml extends Dependency implements Serializable {
 
     public SnakeYaml() {
-        super(null);
+        super(null, "1.24");
     }
 
     @Override
@@ -26,16 +26,5 @@ public final class SnakeYaml extends Dependency implements Serializable {
     @Override
     public String getName() {
         return "snakeyaml";
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public Dependency setVersion(String version) {
-        this.version = version;
-        return this;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/utility/Dependency.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/utility/Dependency.java
@@ -17,27 +17,41 @@ public abstract class Dependency implements Serializable {
     /**
      * The download url of the dependency
      */
-    public String download_url = "http://central.maven.org/maven2/";
+    private String downloadUrl = "http://central.maven.org/maven2/";
 
+    /**
+     * The version of the current dependency
+     */
     public String version;
 
     /**
      * Initializes the dependency using the default url
+     *
+     * @deprecated Use version initialized constructor
      */
+    @Deprecated
     protected Dependency() {
-        this(null);
+        this(null, "1.0");
     }
 
     /**
      * Creates a new constructor of the dependency
      *
-     * @param url The download url of the dependency or {@code null} if the cloud should use the
-     * default url
+     * @param url The download url of the dependency or {@code null} if the
+     *            cloud should use the default url
+     * @param defaultVersion The default version of the dependency if the
+     *                       current version cannot be loaded
      */
-    protected Dependency(final String url) {
+    protected Dependency(final String url, final String defaultVersion) {
         if (url != null) {
-            this.download_url = url;
+            this.downloadUrl = url;
         }
+
+        if (defaultVersion == null) {
+            throw new IllegalStateException("default version may not be null");
+        }
+
+        this.version = defaultVersion;
     }
 
     /**
@@ -59,16 +73,22 @@ public abstract class Dependency implements Serializable {
      *
      * @return The version id of the dependency
      */
-    public abstract String getVersion();
+    public String getVersion() {
+        return this.version;
+    }
 
     /**
      * Sets the version of the current dependency
      *
      * @param version The new version of the dependency
+     * @return The current dependency instance
      */
-    public abstract Dependency setVersion(String version);
+    public Dependency setVersion(String version) {
+        this.version = version;
+        return this;
+    }
 
-    public String getDownload_url() {
-        return this.download_url;
+    public String downloadUrl() {
+        return this.downloadUrl;
     }
 }

--- a/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/utility/Dependency.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-common/src/main/java/systems/reformcloud/utility/Dependency.java
@@ -19,6 +19,8 @@ public abstract class Dependency implements Serializable {
      */
     public String download_url = "http://central.maven.org/maven2/";
 
+    public String version;
+
     /**
      * Initializes the dependency using the default url
      */
@@ -58,6 +60,13 @@ public abstract class Dependency implements Serializable {
      * @return The version id of the dependency
      */
     public abstract String getVersion();
+
+    /**
+     * Sets the version of the current dependency
+     *
+     * @param version The new version of the dependency
+     */
+    public abstract Dependency setVersion(String version);
 
     public String getDownload_url() {
         return this.download_url;

--- a/reformcloud-pre-loader/reformcloud-pre-loader-controller/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-controller/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-pre-loader-common</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 
     <build>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-controller/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-controller/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-pre-loader-common</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 
     <build>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-controller/src/main/java/systems/reformcloud/ControllerPreLoader.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-controller/src/main/java/systems/reformcloud/ControllerPreLoader.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 final class ControllerPreLoader implements Serializable {
 
     public static synchronized void main(String[] args) throws IOException {
-        LibraryPreLoader.prepareDependencies(true);
+        LibraryPreLoader.prepareDependencies(true, true);
         List<URL> libs = LibraryPreLoader.downloadDependencies();
         System.out.println("\nSuccessfully installed all necessary libraries");
 

--- a/reformcloud-pre-loader/reformcloud-pre-loader-process/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-process/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-pre-loader-common</artifactId>
-            <version>1.12</version>
+            <version>1.12.1</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12</version>
+        <version>1.12.1</version>
     </parent>
 
     <build>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-process/pom.xml
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-process/pom.xml
@@ -6,7 +6,7 @@
         <dependency>
             <groupId>systems.reformcloud</groupId>
             <artifactId>reformcloud-pre-loader-common</artifactId>
-            <version>1.12.1</version>
+            <version>1.13</version>
             <scope>compile</scope>
             <type>jar</type>
         </dependency>
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>reformcloud-pre-loader</artifactId>
         <groupId>systems.reformcloud</groupId>
-        <version>1.12.1</version>
+        <version>1.13</version>
     </parent>
 
     <build>

--- a/reformcloud-pre-loader/reformcloud-pre-loader-process/src/main/java/systems/reformcloud/ProcessPreLoader.java
+++ b/reformcloud-pre-loader/reformcloud-pre-loader-process/src/main/java/systems/reformcloud/ProcessPreLoader.java
@@ -69,7 +69,7 @@ final class ProcessPreLoader implements Serializable {
             return;
         }
 
-        LibraryPreLoader.prepareDependencies(false);
+        LibraryPreLoader.prepareDependencies(false, false);
         List<URL> dependencies = LibraryPreLoader.downloadDependencies();
         System.out.println("\nSuccessfully installed all necessary libraries");
         run0(args, target, dependencies);


### PR DESCRIPTION
- Only Proxy Join behoben
- Tab Complete für alle Befehle hinzugefügt
- Mehr Funktionen für Developer
- Spigot & Paper 1.14.4 hinzugefügt
- SpongeVanilla 1.9.4 hinzugefügt
- `/reformcloud maintenance <serverGroup>` hinzugefügt
- OutOfMemory Fehler behoben
 - Performance fixes
 - Viele Bug fixes